### PR TITLE
changed name of solar radiation input of partialReducedOrderModel.mo …

### DIFF
--- a/AixLib/Building/Components/Weather/Sunblind.mo
+++ b/AixLib/Building/Components/Weather/Sunblind.mo
@@ -5,29 +5,31 @@ model Sunblind "Reduces beam at Imax"
     "Total energy transmittances if sunblind is closed";
   parameter Modelica.SIunits.RadiantEnergyFluenceRate Imax = 100
     "Intensity at which the sunblind closes";
-  Utilities.Interfaces.SolarRad_in Rad_In[n] annotation(Placement(transformation(extent = {{-100, 0}, {-80, 20}})));
-  Utilities.Interfaces.SolarRad_out Rad_Out[n] annotation(Placement(transformation(extent = {{80, 0}, {100, 20}})));
+  Utilities.Interfaces.SolarRad_in Rad_in[n] annotation(Placement(transformation(extent = {{-100, 0}, {-80, 20}})));
+  Utilities.Interfaces.SolarRad_out Rad_out[n] annotation(Placement(transformation(extent = {{80, 0}, {100, 20}})));
   Modelica.Blocks.Interfaces.RealOutput sunblindonoff[n] annotation(Placement(transformation(extent = {{-10, -10}, {10, 10}}, rotation = -90, origin = {8, -100}), iconTransformation(extent = {{-10, -10}, {10, 10}}, rotation = -90, origin = {0, -90})));
   /*if OutputSunblind*/
 initial equation
   assert(n == size(gsunblind, 1), "gsunblind has to have n elements");
 equation
   for i in 1:n loop
-    if Rad_In[i].I > Imax then
-      Rad_Out[i].I = Rad_In[i].I * gsunblind[i];
+    if Rad_in[i].I > Imax then
+      Rad_out[i].I = Rad_in[i].I * gsunblind[i];
       sunblindonoff[i] = 1 - gsunblind[i];
     else
-      Rad_Out[i].I = Rad_In[i].I;
+      Rad_out[i].I = Rad_in[i].I;
       sunblindonoff[i] = 0;
     end if;
     //Dummy equation
-    Rad_Out[i].I_dir = sum(Rad_In.I_dir);
-    Rad_Out[i].I_diff = sum(Rad_In.I_diff);
-    Rad_Out[i].I_gr = sum(Rad_In.I_gr);
-    Rad_Out[i].AOI = sum(Rad_In.AOI);
+    Rad_out[i].I_dir = sum(Rad_in.I_dir);
+    Rad_out[i].I_diff = sum(Rad_in.I_diff);
+    Rad_out[i].I_gr = sum(Rad_in.I_gr);
+    Rad_out[i].AOI = sum(Rad_in.AOI);
   end for;
 
-  annotation(Diagram(graphics), Icon(coordinateSystem(preserveAspectRatio=false,
+  annotation(Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},
+            {100,100}}),
+                     graphics), Icon(coordinateSystem(preserveAspectRatio=false,
           extent={{-100,-100},{100,100}}),
                                      graphics={  Rectangle(extent = {{-80, 80}, {80, -80}}, lineColor=
               {0,0,0},                                                                                             fillColor=

--- a/AixLib/Building/LowOrder/BaseClasses/ReducedOrderModel/partialReducedOrderModel.mo
+++ b/AixLib/Building/LowOrder/BaseClasses/ReducedOrderModel/partialReducedOrderModel.mo
@@ -148,7 +148,7 @@ public
         extent={{-10,-10},{10,10}},
         rotation=0,
         origin={-36,64})));
-  Modelica.Blocks.Interfaces.RealInput u1 "Input signal connector"
+  Modelica.Blocks.Interfaces.RealInput solarRad_in "solar radiation input"
     annotation (Placement(transformation(extent={{-134,56},{-94,96}}),
         iconTransformation(
         extent={{-20,-20},{20,20}},
@@ -234,11 +234,11 @@ if withWindows and withOuterwalls then
       points={{-26,64},{-16,64},{-16,0},{-7,0}},
       color={191,0,0},
       smooth=Smooth.None));
-  connect(AbscoeffA1.u, u1) annotation (Line(
+  connect(AbscoeffA1.u, solarRad_in) annotation (Line(
       points={{-70.2,64},{-86,64},{-86,76},{-114,76}},
       color={0,0,127},
       smooth=Smooth.None));
-  connect(AbscoeffA.u, u1) annotation (Line(
+  connect(AbscoeffA.u, solarRad_in) annotation (Line(
       points={{-70.2,90},{-86,90},{-86,76},{-114,76}},
       color={0,0,127},
       smooth=Smooth.None));

--- a/AixLib/Building/LowOrder/BaseClasses/ReducedOrderModel/partialReducedOrderModel.mo
+++ b/AixLib/Building/LowOrder/BaseClasses/ReducedOrderModel/partialReducedOrderModel.mo
@@ -337,7 +337,10 @@ if withWindows and withOuterwalls then
 </ul>
 </html>", revisions="<html>
 <ul>
-<li><i>October 2014,&nbsp;</i> by Peter Remmen:<br/>Implemented.</li>
+<li><i>June 2015,&nbsp;</i> by Moritz Lauster:<br>Changed name solar radiation input from u1 to solRad_in.</li>
+</ul>
+<ul>
+<li><i>October 2014,&nbsp;</i> by Peter Remmen:<br>Implemented.</li>
 </ul>
 </html>"));
 end partialReducedOrderModel;

--- a/AixLib/Building/LowOrder/BaseClasses/ThermalZonePhysics.mo
+++ b/AixLib/Building/LowOrder/BaseClasses/ThermalZonePhysics.mo
@@ -124,11 +124,6 @@ equation
           {4,-90},{4,-7.2},{35.98,-7.2}},                                                                                               color = {0, 0, 127}, smooth = Smooth.None));
   connect(ventilationTemperature, reducedOrderModel.ventilationTemperature) annotation(Line(points = {{-100, -50}, {-12, -50}, {-12, 4.56}, {23.8, 4.56}}, color = {0, 0, 127}, smooth = Smooth.None));
   connect(solarRad_in, sunblind.Rad_In) annotation(Line(points={{-90,70},{-49,70}},                            color = {255, 128, 0}, smooth = Smooth.None));
-  connect(solRadWeightedSum.solarRad_out, reducedOrderModel.u1) annotation (
-      Line(
-      points={{30.6,71},{33.66,71},{33.66,44.32}},
-      color={0,0,127},
-      smooth=Smooth.None));
   connect(solarRadAdapter.solarRad_in, solarRad_in) annotation (Line(
       points={{-73,38},{-76,38},{-76,70},{-90,70}},
       color={255,128,0},
@@ -144,6 +139,11 @@ equation
   connect(partialCorG.solarRadWinTrans, solRadWeightedSum.solarRad_in)
     annotation (Line(
       points={{-5,70},{0,70},{0,71},{5.4,71}},
+      color={0,0,127},
+      smooth=Smooth.None));
+  connect(solRadWeightedSum.solarRad_out, reducedOrderModel.solarRad_in)
+    annotation (Line(
+      points={{30.6,71},{33.66,71},{33.66,44.32}},
       color={0,0,127},
       smooth=Smooth.None));
   annotation(Diagram(coordinateSystem(preserveAspectRatio=false,   extent={{-100,

--- a/AixLib/Building/LowOrder/Examples/LowOrderExample.mo
+++ b/AixLib/Building/LowOrder/Examples/LowOrderExample.mo
@@ -131,8 +131,10 @@ equation
  </html>", revisions="<html>
 <ul>
 <li>October 2014 by Peter Remmen:</li>
+</ul>
 <p>added record for one winter day, now it&apos;s a ready to run example</p>
-<li><i>June 24, 2014 </i>by Moritz Lauster:<br/>Implemented </li>
+<ul>
+<li><i>June 24, 2014 </i>by Moritz Lauster:<br>Implemented </li>
 </ul>
 </html>"),  experiment(StopTime=86400, Interval=3600),           __Dymola_experimentSetupOutput);
 end LowOrderExample;

--- a/AixLib/Building/LowOrder/Examples/Validation/ASHRAE140/Case600.mo
+++ b/AixLib/Building/LowOrder/Examples/Validation/ASHRAE140/Case600.mo
@@ -241,9 +241,9 @@ equation
       points={{-29,64},{-1,64}},
       color={0,0,127},
       smooth=Smooth.None));
-  connect(SolarRadWeightedSum.solarRad_out, reducedOrderModel.u1) annotation (
-      Line(
-      points={{17,64},{21,64},{21,45.42},{21.64,45.42}},
+  connect(SolarRadWeightedSum.solarRad_out, reducedOrderModel.solarRad_in)
+    annotation (Line(
+      points={{17,64},{21.64,64},{21.64,45.42}},
       color={0,0,127},
       smooth=Smooth.None));
   annotation (Diagram(coordinateSystem(

--- a/AixLib/Building/LowOrder/Examples/Validation/ASHRAE140/Case600.mo
+++ b/AixLib/Building/LowOrder/Examples/Validation/ASHRAE140/Case600.mo
@@ -325,8 +325,8 @@ equation
     Documentation(info="<html>
 <p>As described in ASHRAE Standard 140.</p>
 </html>", revisions="<html>
- <p><ul>
- <li><i>March 19, 2015</i> by Peter Remmen:<br/>Implemented</li>
- </ul></p>
- </html>"));
+<ul>
+<li><i>March 19, 2015</i> by Peter Remmen:<br>Implemented </li>
+</ul>
+</html>"));
 end Case600;

--- a/AixLib/Building/LowOrder/Examples/Validation/ASHRAE140/Case600FF.mo
+++ b/AixLib/Building/LowOrder/Examples/Validation/ASHRAE140/Case600FF.mo
@@ -179,9 +179,9 @@ equation
       points={{-29,64},{-1,64}},
       color={0,0,127},
       smooth=Smooth.None));
-  connect(SolarRadWeightedSum.solarRad_out, reducedOrderModel.u1) annotation (
-      Line(
-      points={{17,64},{21,64},{21,45.42},{21.64,45.42}},
+  connect(SolarRadWeightedSum.solarRad_out, reducedOrderModel.solarRad_in)
+    annotation (Line(
+      points={{17,64},{21.64,64},{21.64,45.42}},
       color={0,0,127},
       smooth=Smooth.None));
   annotation (Diagram(coordinateSystem(

--- a/AixLib/Building/LowOrder/Examples/Validation/ASHRAE140/Case620.mo
+++ b/AixLib/Building/LowOrder/Examples/Validation/ASHRAE140/Case620.mo
@@ -241,9 +241,9 @@ equation
       points={{-29,64},{-1,64}},
       color={0,0,127},
       smooth=Smooth.None));
-  connect(SolarRadWeightedSum.solarRad_out, reducedOrderModel.u1) annotation (
-      Line(
-      points={{17,64},{21,64},{21,45.42},{21.64,45.42}},
+  connect(SolarRadWeightedSum.solarRad_out, reducedOrderModel.solarRad_in)
+    annotation (Line(
+      points={{17,64},{21.64,64},{21.64,45.42}},
       color={0,0,127},
       smooth=Smooth.None));
   annotation (Diagram(coordinateSystem(

--- a/AixLib/Building/LowOrder/Examples/Validation/ASHRAE140/Case640.mo
+++ b/AixLib/Building/LowOrder/Examples/Validation/ASHRAE140/Case640.mo
@@ -216,13 +216,13 @@ equation
       points={{-29,64},{-1,64}},
       color={0,0,127},
       smooth=Smooth.None));
-  connect(SolarRadWeightedSum.solarRad_out, reducedOrderModel.u1) annotation (
-      Line(
-      points={{17,64},{21,64},{21,45.42},{21.64,45.42}},
-      color={0,0,127},
-      smooth=Smooth.None));
   connect(Source_TsetHeat.y[1], idealHeaterCooler.soll_heat) annotation (Line(
       points={{25.35,-43.5},{19,-43.5},{19,-28.8}},
+      color={0,0,127},
+      smooth=Smooth.None));
+  connect(SolarRadWeightedSum.solarRad_out, reducedOrderModel.solarRad_in)
+    annotation (Line(
+      points={{17,64},{21.64,64},{21.64,45.42}},
       color={0,0,127},
       smooth=Smooth.None));
   annotation (Diagram(coordinateSystem(

--- a/AixLib/Building/LowOrder/Examples/Validation/ASHRAE140/Case650.mo
+++ b/AixLib/Building/LowOrder/Examples/Validation/ASHRAE140/Case650.mo
@@ -208,11 +208,6 @@ equation
       points={{-29,64},{-1,64}},
       color={0,0,127},
       smooth=Smooth.None));
-  connect(SolarRadWeightedSum.solarRad_out, reducedOrderModel.u1) annotation (
-      Line(
-      points={{17,64},{21,64},{21,45.42},{21.64,45.42}},
-      color={0,0,127},
-      smooth=Smooth.None));
   connect(AirExchangeRate.y[1], reducedOrderModel.ventilationRate) annotation (
       Line(
       points={{-26.35,-43.5},{-24,-43.5},{-24,-11},{22.92,-11},{22.92,12.3}},
@@ -220,6 +215,11 @@ equation
       smooth=Smooth.None));
   connect(Source_TsetCool.y[1], idealHeaterCooler.soll_cool) annotation (Line(
       points={{3.65,-43.5},{11.2,-43.5},{11.2,-28.8}},
+      color={0,0,127},
+      smooth=Smooth.None));
+  connect(SolarRadWeightedSum.solarRad_out, reducedOrderModel.solarRad_in)
+    annotation (Line(
+      points={{17,64},{21.64,64},{21.64,45.42}},
       color={0,0,127},
       smooth=Smooth.None));
   annotation (Diagram(coordinateSystem(

--- a/AixLib/Building/LowOrder/Examples/Validation/ASHRAE140/Case650FF.mo
+++ b/AixLib/Building/LowOrder/Examples/Validation/ASHRAE140/Case650FF.mo
@@ -179,14 +179,14 @@ FreeFloatTemperature = reducedOrderModel.airload.T;
       points={{-29,64},{-1,64}},
       color={0,0,127},
       smooth=Smooth.None));
-  connect(SolarRadWeightedSum.solarRad_out, reducedOrderModel.u1) annotation (
-      Line(
-      points={{17,64},{21,64},{21,45.42},{21.64,45.42}},
-      color={0,0,127},
-      smooth=Smooth.None));
   connect(AirExchangeRate.y[1], reducedOrderModel.ventilationRate) annotation (
       Line(
       points={{-26.35,-43.5},{-24,-43.5},{-24,-11},{22.92,-11},{22.92,12.3}},
+      color={0,0,127},
+      smooth=Smooth.None));
+  connect(SolarRadWeightedSum.solarRad_out, reducedOrderModel.solarRad_in)
+    annotation (Line(
+      points={{17,64},{21.64,64},{21.64,45.42}},
       color={0,0,127},
       smooth=Smooth.None));
   annotation (Diagram(coordinateSystem(

--- a/AixLib/Building/LowOrder/Examples/Validation/ASHRAE140/Case900.mo
+++ b/AixLib/Building/LowOrder/Examples/Validation/ASHRAE140/Case900.mo
@@ -211,9 +211,9 @@ equation
       points={{-29,64},{-1,64}},
       color={0,0,127},
       smooth=Smooth.None));
-  connect(SolarRadWeightedSum.solarRad_out, reducedOrderModel.u1) annotation (
-      Line(
-      points={{17,64},{21,64},{21,45.42},{21.64,45.42}},
+  connect(SolarRadWeightedSum.solarRad_out, reducedOrderModel.solarRad_in)
+    annotation (Line(
+      points={{17,64},{21.64,64},{21.64,45.42}},
       color={0,0,127},
       smooth=Smooth.None));
   annotation (Diagram(coordinateSystem(

--- a/AixLib/Building/LowOrder/Examples/Validation/ASHRAE140/Case900FF.mo
+++ b/AixLib/Building/LowOrder/Examples/Validation/ASHRAE140/Case900FF.mo
@@ -204,9 +204,9 @@ equation
       points={{-29,64},{-1,64}},
       color={0,0,127},
       smooth=Smooth.None));
-  connect(SolarRadWeightedSum.solarRad_out, reducedOrderModel.u1) annotation (
-      Line(
-      points={{17,64},{21,64},{21,45.42},{21.64,45.42}},
+  connect(SolarRadWeightedSum.solarRad_out, reducedOrderModel.solarRad_in)
+    annotation (Line(
+      points={{17,64},{21.64,64},{21.64,45.42}},
       color={0,0,127},
       smooth=Smooth.None));
   annotation (Diagram(coordinateSystem(

--- a/AixLib/Building/LowOrder/Examples/Validation/ASHRAE140/Case920.mo
+++ b/AixLib/Building/LowOrder/Examples/Validation/ASHRAE140/Case920.mo
@@ -212,9 +212,9 @@ equation
       points={{-29,64},{-1,64}},
       color={0,0,127},
       smooth=Smooth.None));
-  connect(SolarRadWeightedSum.solarRad_out, reducedOrderModel.u1) annotation (
-      Line(
-      points={{17,64},{21,64},{21,45.42},{21.64,45.42}},
+  connect(SolarRadWeightedSum.solarRad_out, reducedOrderModel.solarRad_in)
+    annotation (Line(
+      points={{17,64},{21.64,64},{21.64,45.42}},
       color={0,0,127},
       smooth=Smooth.None));
   annotation (Diagram(coordinateSystem(

--- a/AixLib/Building/LowOrder/Examples/Validation/ASHRAE140/Case940.mo
+++ b/AixLib/Building/LowOrder/Examples/Validation/ASHRAE140/Case940.mo
@@ -215,13 +215,13 @@ equation
       points={{-29,64},{-1,64}},
       color={0,0,127},
       smooth=Smooth.None));
-  connect(SolarRadWeightedSum.solarRad_out, reducedOrderModel.u1) annotation (
-      Line(
-      points={{17,64},{21,64},{21,45.42},{21.64,45.42}},
-      color={0,0,127},
-      smooth=Smooth.None));
   connect(Source_TsetHeat.y[1], idealHeaterCooler.soll_heat) annotation (Line(
       points={{27.35,-43.5},{19,-43.5},{19,-28.8}},
+      color={0,0,127},
+      smooth=Smooth.None));
+  connect(SolarRadWeightedSum.solarRad_out, reducedOrderModel.solarRad_in)
+    annotation (Line(
+      points={{17,64},{21.64,64},{21.64,45.42}},
       color={0,0,127},
       smooth=Smooth.None));
   annotation (Diagram(coordinateSystem(

--- a/AixLib/Building/LowOrder/Examples/Validation/ASHRAE140/Case950.mo
+++ b/AixLib/Building/LowOrder/Examples/Validation/ASHRAE140/Case950.mo
@@ -210,11 +210,6 @@ equation
       points={{-29,64},{-1,64}},
       color={0,0,127},
       smooth=Smooth.None));
-  connect(SolarRadWeightedSum.solarRad_out, reducedOrderModel.u1) annotation (
-      Line(
-      points={{17,64},{21,64},{21,45.42},{21.64,45.42}},
-      color={0,0,127},
-      smooth=Smooth.None));
   connect(Source_TsetHeat.y[1], idealHeaterCooler.soll_cool) annotation (Line(
       points={{5.65,-43.5},{11.2,-43.5},{11.2,-28.8}},
       color={0,0,127},
@@ -222,6 +217,11 @@ equation
   connect(AirExchangeRate.y[1], reducedOrderModel.ventilationRate) annotation (
       Line(
       points={{-26.35,-43.5},{-19,-43.5},{-19,-11},{22.92,-11},{22.92,12.3}},
+      color={0,0,127},
+      smooth=Smooth.None));
+  connect(SolarRadWeightedSum.solarRad_out, reducedOrderModel.solarRad_in)
+    annotation (Line(
+      points={{17,64},{21.64,64},{21.64,45.42}},
       color={0,0,127},
       smooth=Smooth.None));
   annotation (Diagram(coordinateSystem(

--- a/AixLib/Building/LowOrder/Examples/Validation/ASHRAE140/Case950FF.mo
+++ b/AixLib/Building/LowOrder/Examples/Validation/ASHRAE140/Case950FF.mo
@@ -180,14 +180,14 @@ equation
       points={{-29,64},{-1,64}},
       color={0,0,127},
       smooth=Smooth.None));
-  connect(SolarRadWeightedSum.solarRad_out, reducedOrderModel.u1) annotation (
-      Line(
-      points={{17,64},{21,64},{21,45.42},{21.64,45.42}},
-      color={0,0,127},
-      smooth=Smooth.None));
   connect(AirExchangeRate.y[1], reducedOrderModel.ventilationRate) annotation (
       Line(
       points={{-26.35,-43.5},{-19,-43.5},{-19,-11},{22.92,-11},{22.92,12.3}},
+      color={0,0,127},
+      smooth=Smooth.None));
+  connect(SolarRadWeightedSum.solarRad_out, reducedOrderModel.solarRad_in)
+    annotation (Line(
+      points={{17,64},{21.64,64},{21.64,45.42}},
       color={0,0,127},
       smooth=Smooth.None));
   annotation (Diagram(coordinateSystem(

--- a/AixLib/Building/LowOrder/Examples/Validation/VDI6007/Linear/TestCase_1.mo
+++ b/AixLib/Building/LowOrder/Examples/Validation/VDI6007/Linear/TestCase_1.mo
@@ -29,7 +29,7 @@ equation
           {10.54,-40},{10.54,1.7}},                                                                                        color = {0, 0, 127}, smooth = Smooth.None));
   connect(machinesConvective.port, reducedModel.internalGainsConv) annotation(Line(points={{12,-76},
           {20.4,-76},{20.4,1.7}},                                                                                                  color = {191, 0, 0}, smooth = Smooth.None));
-  connect(solarRadiation.y, reducedModel.u1) annotation (Line(
+  connect(solarRadiation.y, reducedModel.solarRad_in) annotation (Line(
       points={{-35,62},{9.18,62},{9.18,32.98}},
       color={0,0,127},
       smooth=Smooth.None));

--- a/AixLib/Building/LowOrder/Examples/Validation/VDI6007/Linear/TestCase_10.mo
+++ b/AixLib/Building/LowOrder/Examples/Validation/VDI6007/Linear/TestCase_10.mo
@@ -7,7 +7,8 @@ model TestCase_10
   Modelica.Blocks.Sources.Constant infiltrationTemp(k = 22) annotation(Placement(transformation(extent = {{16, 0}, {26, 10}})));
   Modelica.Blocks.Sources.CombiTimeTable windowRad(extrapolation = Modelica.Blocks.Types.Extrapolation.Periodic, table = [0, 0, 0, 0, 0, 0.0; 3600, 0, 0, 0, 0, 0.0; 10800, 0, 0, 0, 0, 0.0; 14400, 0, 0, 0, 0, 0.0; 14400, 0, 0, 17, 0, 0.0; 18000, 0, 0, 17, 0, 0.0; 18000, 0, 0, 38, 0, 0.0; 21600, 0, 0, 38, 0, 0.0; 21600, 0, 0, 59, 0, 0.0; 25200, 0, 0, 59, 0, 0.0; 25200, 0, 0, 98, 0, 0.0; 28800, 0, 0, 98, 0, 0.0; 28800, 0, 0, 186, 0, 0.0; 32400, 0, 0, 186, 0, 0.0; 32400, 0, 0, 287, 0, 0.0; 36000, 0, 0, 287, 0, 0.0; 36000, 0, 0, 359, 0, 0.0; 39600, 0, 0, 359, 0, 0.0; 39600, 0, 0, 385, 0, 0.0; 43200, 0, 0, 385, 0, 0.0; 43200, 0, 0, 359, 0, 0.0; 46800, 0, 0, 359, 0, 0.0; 46800, 0, 0, 287, 0, 0.0; 50400, 0, 0, 287, 0, 0.0; 50400, 0, 0, 186, 0, 0.0; 54000, 0, 0, 186, 0, 0.0; 54000, 0, 0, 98, 0, 0.0; 57600, 0, 0, 98, 0, 0.0; 57600, 0, 0, 59, 0, 0.0; 61200, 0, 0, 59, 0, 0.0; 61200, 0, 0, 38, 0, 0.0; 64800, 0, 0, 38, 0, 0.0; 64800, 0, 0, 17, 0, 0.0; 68400, 0, 0, 17, 0, 0.0; 68400, 0, 0, 0, 0, 0.0; 72000, 0, 0, 0, 0, 0.0; 82800, 0, 0, 0, 0, 0.0; 86400, 0, 0, 0, 0, 0.0], columns = {2, 3, 4, 5, 6}) annotation(Placement(transformation(extent = {{-86, 72}, {-66, 92}})));
   Utilities.Sources.PrescribedSolarRad Quelle_Fenster(n = 5) annotation(Placement(transformation(extent = {{-50, 72}, {-30, 92}})));
-  Components.Weather.Sunblind sunblind(n = 5, gsunblind = {0, 0, 0.15, 0, 0}) annotation(Placement(transformation(extent = {{-20, 71}, {0, 91}})));
+  Components.Weather.Sunblind sunblind(n = 5, gsunblind = {0, 0, 0.15, 0, 0}) annotation(Placement(transformation(extent={{-20,71},
+            {0,91}})));
   Building.LowOrder.BaseClasses.SolarRadWeightedSum rad_weighted_sum(n = 5, weightfactors = {0, 0, 7, 0, 0}) annotation(Placement(transformation(extent={{28,72},
             {48,92}})));
   BaseClasses.EqAirTemp.EqAirTempSimple eqAirTemp_TestCase_8_1(
@@ -55,7 +56,6 @@ model TestCase_10
 equation
   referenceTemp = reference.y;
   simulationTemp = reducedModel.airload.port.T;
-  connect(Quelle_Fenster.solarRad_out, sunblind.Rad_In) annotation(Line(points = {{-31, 82}, {-19, 82}}, color = {255, 128, 0}, smooth = Smooth.None));
   connect(wallRad.y, multiplex5_1.u1[1]) annotation(Line(points = {{-115.5, 55}, {-104, 55}, {-104, 64}, {-86, 64}}, color = {0, 0, 127}, smooth = Smooth.None));
   connect(wallRad.y, multiplex5_1.u2[1]) annotation(Line(points = {{-115.5, 55}, {-104, 55}, {-104, 59}, {-86, 59}}, color = {0, 0, 127}, smooth = Smooth.None));
   connect(wallRad.y, multiplex5_1.u3[1]) annotation(Line(points = {{-115.5, 55}, {-104, 55}, {-104, 54}, {-86, 54}}, color = {0, 0, 127}, smooth = Smooth.None));
@@ -126,10 +126,6 @@ equation
       points={{-65,82},{-58,82},{-58,75},{-49,75}},
       color={0,0,127},
       smooth=Smooth.None));
-  connect(rad_weighted_sum.solarRad_out, reducedModel.u1) annotation (Line(
-      points={{47,82},{46,82},{46,98},{64.96,98},{64.96,90.5}},
-      color={0,0,127},
-      smooth=Smooth.None));
   connect(Quelle_Wand.solarRad_out, solarRadAdapter1.solarRad_in) annotation (
       Line(
       points={{-39,54},{-39,54}},
@@ -140,13 +136,22 @@ equation
       points={{-20,54},{-20,25.6},{-18.5,25.6}},
       color={0,0,127},
       smooth=Smooth.None));
-  connect(sunblind.Rad_Out, solarRadAdapter2.solarRad_in) annotation (Line(
-      points={{-1,82},{3,82}},
-      color={255,128,0},
-      smooth=Smooth.None));
   connect(solarRadAdapter2.solarRad_out, rad_weighted_sum.solarRad_in)
     annotation (Line(
       points={{22,82},{29,82}},
+      color={0,0,127},
+      smooth=Smooth.None));
+  connect(Quelle_Fenster.solarRad_out, sunblind.Rad_in) annotation (Line(
+      points={{-31,82},{-19,82}},
+      color={255,128,0},
+      smooth=Smooth.None));
+  connect(sunblind.Rad_out, solarRadAdapter2.solarRad_in) annotation (Line(
+      points={{-1,82},{3,82}},
+      color={255,128,0},
+      smooth=Smooth.None));
+  connect(rad_weighted_sum.solarRad_out, reducedModel.solarRad_in) annotation (
+      Line(
+      points={{47,82},{52,82},{52,98},{64.96,98},{64.96,90.5}},
       color={0,0,127},
       smooth=Smooth.None));
   annotation(Diagram(coordinateSystem(preserveAspectRatio=false,   extent={{-100,

--- a/AixLib/Building/LowOrder/Examples/Validation/VDI6007/Linear/TestCase_11.mo
+++ b/AixLib/Building/LowOrder/Examples/Validation/VDI6007/Linear/TestCase_11.mo
@@ -76,7 +76,7 @@ equation
       color={191,0,0},
       smooth=Smooth.None));
   connect(cooler.heatCoolRoom, reducedModel.heatConvInnerwall.port_b);
-  connect(solarRadiation.y, reducedModel.u1) annotation (Line(
+  connect(solarRadiation.y, reducedModel.solarRad_in) annotation (Line(
       points={{-15,82},{73.18,82},{73.18,74.8}},
       color={0,0,127},
       smooth=Smooth.None));
@@ -86,8 +86,7 @@ equation
         "Simulate and plot"),
              __Dymola_experimentSetupOutput(events = false), Icon(graphics),
              Diagram(coordinateSystem(preserveAspectRatio=false,
-             extent={{-100,
-                      -100},{100,100}}),
+             extent={{-100,-100},{100,100}}),
                       graphics),
             Documentation(revisions="<html>
 <p><ul>

--- a/AixLib/Building/LowOrder/Examples/Validation/VDI6007/Linear/TestCase_12.mo
+++ b/AixLib/Building/LowOrder/Examples/Validation/VDI6007/Linear/TestCase_12.mo
@@ -32,7 +32,6 @@ equation
   simulationTemp = reducedModel.airload.port.T;
   connect(outdoorTemp.y[1], varTemp.T) annotation(Line(points={{-39,28},{-22,28},
           {-22,38},{-2,38}},                                                                                 color = {0, 0, 127}, smooth = Smooth.None));
-  connect(Quelle_Fenster.solarRad_out, sunblind.Rad_In) annotation(Line(points = {{-35, 82}, {-23, 82}}, color = {255, 128, 0}, smooth = Smooth.None));
   connect(varTemp.port, reducedModel.equalAirTemp) annotation(Line(points={{20,38},
           {28,38},{28,50.8},{57.4,50.8}},                                                                                   color = {191, 0, 0}, smooth = Smooth.None));
   connect(HeatTorStar.Star, reducedModel.internalGainsRad) annotation(Line(points={{67.1,
@@ -75,18 +74,23 @@ equation
       points={{-61,82},{-58,82},{-58,75},{-53,75}},
       color={0,0,127},
       smooth=Smooth.None));
-  connect(rad_weighted_sum.solarRad_out, reducedModel.u1) annotation (Line(
-      points={{49,82},{56,82},{56,80},{63.18,80},{63.18,68.8}},
-      color={0,0,127},
-      smooth=Smooth.None));
   connect(solarRadAdapter2.solarRad_out, rad_weighted_sum.solarRad_in)
     annotation (Line(
       points={{24,82},{31,82}},
       color={0,0,127},
       smooth=Smooth.None));
-  connect(solarRadAdapter2.solarRad_in, sunblind.Rad_Out) annotation (Line(
-      points={{5,82},{-5,82}},
+  connect(Quelle_Fenster.solarRad_out, sunblind.Rad_in) annotation (Line(
+      points={{-35,82},{-23,82}},
       color={255,128,0},
+      smooth=Smooth.None));
+  connect(sunblind.Rad_out, solarRadAdapter2.solarRad_in) annotation (Line(
+      points={{-5,82},{5,82}},
+      color={255,128,0},
+      smooth=Smooth.None));
+  connect(rad_weighted_sum.solarRad_out, reducedModel.solarRad_in) annotation (
+      Line(
+      points={{49,82},{63.18,82},{63.18,68.8}},
+      color={0,0,127},
       smooth=Smooth.None));
   annotation(Diagram(coordinateSystem(preserveAspectRatio=false,   extent={{-100,
             -100},{100,100}}),

--- a/AixLib/Building/LowOrder/Examples/Validation/VDI6007/Linear/TestCase_2.mo
+++ b/AixLib/Building/LowOrder/Examples/Validation/VDI6007/Linear/TestCase_2.mo
@@ -28,11 +28,12 @@ equation
           {20,-30},{20,11.7},{22.54,11.7}},                                                                                            color = {0, 0, 127}, smooth = Smooth.None));
   connect(HeatToStar.Star, reducedModel.internalGainsRad) annotation(Line(points={{70,
           -28.9},{70,-18},{41.75,-18},{41.75,11.7}},                                                                                      color = {95, 95, 95}, pattern = LinePattern.None, smooth = Smooth.None));
-  connect(solarRadiation.y, reducedModel.u1) annotation (Line(
+  connect(solarRadiation.y, reducedModel.solarRad_in) annotation (Line(
       points={{-25,72},{21.18,72},{21.18,42.98}},
       color={0,0,127},
       smooth=Smooth.None));
-  annotation(Diagram(coordinateSystem(preserveAspectRatio = false, extent = {{-100, -100}, {100, 100}}), graphics),
+  annotation(Diagram(coordinateSystem(preserveAspectRatio=false,   extent={{-100,
+            -100},{100,100}}),                                                                           graphics),
              experiment(StopTime = 5.184e+006, Interval = 3600),
              __Dymola_Commands(file=
                                "modelica://AixLib/Resources/Scripts/Dymola/Building/LowOrder/Examples/Validation/Linear/TestCase_2.mos"

--- a/AixLib/Building/LowOrder/Examples/Validation/VDI6007/Linear/TestCase_3.mo
+++ b/AixLib/Building/LowOrder/Examples/Validation/VDI6007/Linear/TestCase_3.mo
@@ -25,7 +25,7 @@ equation
           {22,-30},{22,11.7},{22.54,11.7}},                                                                                            color = {0, 0, 127}, smooth = Smooth.None));
   connect(machinesConvective.port, reducedModel.internalGainsConv) annotation(Line(points={{24,-58},
           {32.4,-58},{32.4,11.7}},                                                                                                  color = {191, 0, 0}, smooth = Smooth.None));
-  connect(solarRadiation.y, reducedModel.u1) annotation (Line(
+  connect(solarRadiation.y, reducedModel.solarRad_in) annotation (Line(
       points={{-25,72},{21.18,72},{21.18,42.98}},
       color={0,0,127},
       smooth=Smooth.None));
@@ -52,6 +52,6 @@ equation
                                "modelica://AixLib/Resources/Scripts/Dymola/Building/LowOrder/Examples/Validation/Linear/TestCase_3.mos"
         "Simulate and plot"),
             __Dymola_experimentSetupOutput(events = false),
-            Diagram(coordinateSystem(preserveAspectRatio = false,
-            extent = {{-100, -100}, {100, 100}}), graphics));
+            Diagram(coordinateSystem(preserveAspectRatio=false,
+            extent={{-100,-100},{100,100}}),      graphics));
 end TestCase_3;

--- a/AixLib/Building/LowOrder/Examples/Validation/VDI6007/Linear/TestCase_4.mo
+++ b/AixLib/Building/LowOrder/Examples/Validation/VDI6007/Linear/TestCase_4.mo
@@ -41,7 +41,7 @@ equation
           {18,-30},{18,11.7},{20.54,11.7}},                                                                                            color = {0, 0, 127}, smooth = Smooth.None));
   connect(HeatToStar.Star, reducedModel.internalGainsRad) annotation(Line(points={{55.1,
           -58},{58,-58},{58,-10},{39.75,-10},{39.75,11.7}},                                                                                          color = {95, 95, 95}, pattern = LinePattern.None, smooth = Smooth.None));
-  connect(solarRadiation.y, reducedModel.u1) annotation (Line(
+  connect(solarRadiation.y, reducedModel.solarRad_in) annotation (Line(
       points={{-25,72},{19.18,72},{19.18,42.98}},
       color={0,0,127},
       smooth=Smooth.None));
@@ -62,8 +62,8 @@ equation
  <p>Variable path: <code>reducedModel.airload.T</code></p>
  <p><br><br>All values are given in the VDI 6007-1.</p>
  <p>Same Test Case exists in VDI 6020.</p>
- </html>"),  Diagram(coordinateSystem(preserveAspectRatio = false,
-             extent = {{-100, -100}, {100, 100}}), graphics),
+ </html>"),  Diagram(coordinateSystem(preserveAspectRatio=false,
+             extent={{-100,-100},{100,100}}),      graphics),
              Icon(graphics),
              experiment(StopTime = 5.184e+006, Interval = 3600),
              __Dymola_Commands(file=

--- a/AixLib/Building/LowOrder/Examples/Validation/VDI6007/Linear/TestCase_5.mo
+++ b/AixLib/Building/LowOrder/Examples/Validation/VDI6007/Linear/TestCase_5.mo
@@ -35,7 +35,8 @@ model TestCase_5
     columns={2,3,4,5,6})
     annotation (Placement(transformation(extent={{-94,68},{-74,88}})));
   Utilities.Sources.PrescribedSolarRad PrescribedSolarRad(n = 5) annotation(Placement(transformation(extent = {{-60, 68}, {-40, 88}})));
-  Components.Weather.Sunblind sunblind(n = 5, gsunblind = {0, 0, 0.15, 0, 0}) annotation(Placement(transformation(extent = {{-30, 67}, {-10, 87}})));
+  Components.Weather.Sunblind sunblind(n = 5, gsunblind = {0, 0, 0.15, 0, 0}) annotation(Placement(transformation(extent={{-36,67},
+            {-16,87}})));
   Building.LowOrder.BaseClasses.SolarRadWeightedSum SolarRadWeightedSum(n = 5, weightfactors = {0, 0, 7, 0, 0}) annotation(Placement(transformation(extent={{18,68},
             {38,88}})));
   Modelica.Thermal.HeatTransfer.Sources.PrescribedTemperature varTemp annotation(Placement(transformation(extent = {{-8, 22}, {12, 42}})));
@@ -47,7 +48,6 @@ equation
   simulationTemp = reducedModel.airload.port.T;
   connect(personsRadiative.port, HeatToStar.Therm) annotation(Line(points = {{30, -90}, {42.8, -90}}, color = {191, 0, 0}, smooth = Smooth.None));
   connect(outdoorTemp.y[1], varTemp.T) annotation(Line(points = {{-41, 32}, {-10, 32}}, color = {0, 0, 127}, smooth = Smooth.None));
-  connect(PrescribedSolarRad.solarRad_out, sunblind.Rad_In) annotation(Line(points = {{-41, 78}, {-29, 78}}, color = {255, 128, 0}, smooth = Smooth.None));
   connect(varTemp.port, reducedModel.equalAirTemp) annotation(Line(points = {{12, 32}, {22, 32}, {22, 46.8}, {51.4, 46.8}}, color = {191, 0, 0}, smooth = Smooth.None));
   connect(infiltrationTemp.y, reducedModel.ventilationTemperature) annotation(Line(points = {{16.5, 1}, {16.5, 18.5}, {51.4, 18.5}, {51.4, 36.4}}, color = {0, 0, 127}, smooth = Smooth.None));
   connect(infiltrationRate.y, reducedModel.ventilationRate) annotation(Line(points={{40.5,1},
@@ -61,10 +61,6 @@ equation
   connect(innerLoads.y[3], machinesConvective.Q_flow) annotation(Line(points = {{-37, -62}, {-18, -62}, {-18, -42}, {10, -42}}, color = {0, 0, 127}, smooth = Smooth.None));
   connect(innerLoads.y[2], personsConvective.Q_flow) annotation(Line(points = {{-37, -62}, {10, -62}}, color = {0, 0, 127}, smooth = Smooth.None));
   connect(innerLoads.y[1], personsRadiative.Q_flow) annotation(Line(points = {{-37, -62}, {-18, -62}, {-18, -90}, {10, -90}}, color = {0, 0, 127}, smooth = Smooth.None));
-  connect(SolarRadWeightedSum.solarRad_out, reducedModel.u1) annotation (Line(
-      points={{37,78},{57.18,78},{57.18,64.8}},
-      color={0,0,127},
-      smooth=Smooth.None));
   connect(windowRad.y, PrescribedSolarRad.I) annotation (Line(
       points={{-73,78},{-66,78},{-66,86.9},{-58.9,86.9}},
       color={0,0,127},
@@ -90,8 +86,17 @@ equation
       points={{12,78},{19,78}},
       color={0,0,127},
       smooth=Smooth.None));
-  connect(sunblind.Rad_Out, solarRadAdapter.solarRad_in) annotation (Line(
-      points={{-11,78},{-7,78}},
+  connect(SolarRadWeightedSum.solarRad_out, reducedModel.solarRad_in)
+    annotation (Line(
+      points={{37,78},{57.18,78},{57.18,64.8}},
+      color={0,0,127},
+      smooth=Smooth.None));
+  connect(PrescribedSolarRad.solarRad_out, sunblind.Rad_in) annotation (Line(
+      points={{-41,78},{-35,78}},
+      color={255,128,0},
+      smooth=Smooth.None));
+  connect(sunblind.Rad_out, solarRadAdapter.solarRad_in) annotation (Line(
+      points={{-17,78},{-7,78}},
       color={255,128,0},
       smooth=Smooth.None));
   annotation(Diagram(coordinateSystem(preserveAspectRatio=false,   extent={{-100,

--- a/AixLib/Building/LowOrder/Examples/Validation/VDI6007/Linear/TestCase_6.mo
+++ b/AixLib/Building/LowOrder/Examples/Validation/VDI6007/Linear/TestCase_6.mo
@@ -36,12 +36,12 @@ equation
   connect(setTemp.y[1], varTemp.T) annotation(Line(points = {{-41, -28}, {-8, -28}}, color = {0, 0, 127}, smooth = Smooth.None));
   connect(heatFlowSensor.port_b, reducedModel.internalGainsConv) annotation(Line(points={{44,-28},
           {74.4,-28},{74.4,28}},                                                                                                color = {191, 0, 0}, smooth = Smooth.None));
-  connect(solarRadiation.y, reducedModel.u1) annotation (Line(
+  connect(solarRadiation.y, reducedModel.solarRad_in) annotation (Line(
       points={{-15,82},{63.18,82},{63.18,64.8}},
       color={0,0,127},
       smooth=Smooth.None));
-  annotation(Diagram(coordinateSystem(preserveAspectRatio = false,
-             extent = {{-100, -100}, {100, 100}}),
+  annotation(Diagram(coordinateSystem(preserveAspectRatio=false,
+             extent={{-100,-100},{100,100}}),
              graphics),
              experiment(StopTime = 5.184e+006,
              Interval = 3600, __Dymola_Algorithm = "Lsodar"),

--- a/AixLib/Building/LowOrder/Examples/Validation/VDI6007/Linear/TestCase_7.mo
+++ b/AixLib/Building/LowOrder/Examples/Validation/VDI6007/Linear/TestCase_7.mo
@@ -41,12 +41,12 @@ equation
           -10},{56.54,-10},{56.54,38}},                                                                                      color = {0, 0, 127}, smooth = Smooth.None));
   connect(heatToStar.Star, reducedModel.internalGainsRad) annotation(Line(points={{59.1,
           -89},{72,-89},{72,38},{75.75,38}},                                                                                        color = {95, 95, 95}, pattern = LinePattern.None, smooth = Smooth.None));
-  connect(solarRadiation.y, reducedModel.u1) annotation (Line(
+  connect(solarRadiation.y, reducedModel.solarRad_in) annotation (Line(
       points={{-27,86},{55.18,86},{55.18,74.8}},
       color={0,0,127},
       smooth=Smooth.None));
-  annotation(Diagram(coordinateSystem(preserveAspectRatio = false,
-                     extent = {{-100, -100}, {100, 100}}),
+  annotation(Diagram(coordinateSystem(preserveAspectRatio=false,
+                     extent={{-100,-100},{100,100}}),
                      graphics),
              experiment(StopTime = 5.184e+006, Interval = 3600, Algorithm = "Lsodar"),
              __Dymola_Commands(file=

--- a/AixLib/Building/LowOrder/Examples/Validation/VDI6007/Linear/TestCase_8.mo
+++ b/AixLib/Building/LowOrder/Examples/Validation/VDI6007/Linear/TestCase_8.mo
@@ -39,7 +39,6 @@ model TestCase_8
 equation
   referenceTemp = reference.y;
   simulationTemp = reducedModel.airload.port.T;
-  connect(Quelle_Fenster.solarRad_out, sunblind.Rad_In) annotation(Line(points = {{-41, 78}, {-29, 78}}, color = {255, 128, 0}, smooth = Smooth.None));
   connect(sunblind.sunblindonoff, eqAirTemp.sunblindsig) annotation(Line(points = {{-20, 68}, {-14, 68}, {-14, 48}, {-6, 48}}, color = {0, 0, 127}, smooth = Smooth.None));
   connect(infiltrationRate.y, reducedModel.ventilationRate) annotation(Line(points={{48.5,0},
           {58.54,0},{58.54,28}},                                                                                         color = {0, 0, 127}, smooth = Smooth.None));
@@ -61,14 +60,6 @@ equation
   connect(eqAirTemp.equalAirTemp, reducedModel.equalAirTemp) annotation (Line(
       points={{3.8,34.4},{14,34.4},{14,34},{26,34},{26,46.8},{51.4,46.8}},
       color={191,0,0},
-      smooth=Smooth.None));
-  connect(rad_weighted_sum.solarRad_out, reducedModel.u1) annotation (Line(
-      points={{39,78},{57.18,78},{57.18,64.8}},
-      color={0,0,127},
-      smooth=Smooth.None));
-  connect(sunblind.Rad_Out, solarRadAdapter.solarRad_in) annotation (Line(
-      points={{-11,78},{-1,78}},
-      color={255,128,0},
       smooth=Smooth.None));
   connect(rad_weighted_sum.solarRad_in, solarRadAdapter.solarRad_out)
     annotation (Line(
@@ -123,6 +114,19 @@ equation
   connect(eqAirTemp.solarRad_in, solarRadAdapter1.solarRad_out) annotation (
       Line(
       points={{-14.5,45.6},{-16,45.6},{-16,46},{-18,46}},
+      color={0,0,127},
+      smooth=Smooth.None));
+  connect(Quelle_Fenster.solarRad_out, sunblind.Rad_in) annotation (Line(
+      points={{-41,78},{-29,78}},
+      color={255,128,0},
+      smooth=Smooth.None));
+  connect(sunblind.Rad_out, solarRadAdapter.solarRad_in) annotation (Line(
+      points={{-11,78},{-1,78}},
+      color={255,128,0},
+      smooth=Smooth.None));
+  connect(rad_weighted_sum.solarRad_out, reducedModel.solarRad_in) annotation (
+      Line(
+      points={{39,78},{57.18,78},{57.18,64.8}},
       color={0,0,127},
       smooth=Smooth.None));
   annotation(Diagram(coordinateSystem(preserveAspectRatio=false,   extent={{-100,

--- a/AixLib/Building/LowOrder/Examples/Validation/VDI6007/Linear/TestCase_9.mo
+++ b/AixLib/Building/LowOrder/Examples/Validation/VDI6007/Linear/TestCase_9.mo
@@ -44,7 +44,6 @@ equation
   simulationTemp = reducedModel.airload.port.T;
   connect(sunblind.sunblindonoff, eqAirTemp.sunblindsig) annotation(Line(points={{-10,63},
           {-10,20}},                                                                                      color = {0, 0, 127}, smooth = Smooth.None));
-  connect(varRad3.solarRad_out, sunblind.Rad_In) annotation(Line(points = {{-39, 73}, {-19, 73}}, color = {255, 128, 0}, smooth = Smooth.None));
   connect(outdoorTemp.y, deMultiplex3_1.u) annotation(Line(points = {{-73.3, 10}, {-69.2, 10}}, color = {0, 0, 127}, smooth = Smooth.None));
   connect(deMultiplex3_1.y1[1], from_degC.u) annotation(Line(points = {{-55.4, 14.2}, {-52.7, 14.2}, {-52.7, 14}, {-50.6, 14}}, color = {0, 0, 127}, smooth = Smooth.None));
   connect(from_degC.y, multiplex3_1.u1[1]) annotation(Line(points = {{-43.7, 14}, {-39.95, 14}, {-39.95, 14.2}, {-38.2, 14.2}}, color = {0, 0, 127}, smooth = Smooth.None));
@@ -107,15 +106,6 @@ equation
       points={{-83.3,33},{-68.65,33},{-68.65,26},{-63,26}},
       color={0,0,127},
       smooth=Smooth.None));
-  connect(window_shortwave_rad_sum.solarRad_out, reducedModel.u1) annotation (
-      Line(
-      points={{52.9,73},{52.9,59.5},{49.34,59.5},{49.34,44.86}},
-      color={0,0,127},
-      smooth=Smooth.None));
-  connect(sunblind.Rad_Out, solarRadAdapter.solarRad_in) annotation (Line(
-      points={{-1,73},{4,73},{4,72},{9,72}},
-      color={255,128,0},
-      smooth=Smooth.None));
   connect(window_shortwave_rad_sum.solarRad_in, solarRadAdapter.solarRad_out)
     annotation (Line(
       points={{33.1,73},{30,73},{30,72},{28,72}},
@@ -128,6 +118,19 @@ equation
   connect(solarRadAdapter1.solarRad_out, eqAirTemp.solarRad_in) annotation (
       Line(
       points={{-24,34},{-24,17.6},{-18.5,17.6}},
+      color={0,0,127},
+      smooth=Smooth.None));
+  connect(varRad3.solarRad_out, sunblind.Rad_in) annotation (Line(
+      points={{-39,73},{-28.5,73},{-28.5,73},{-19,73}},
+      color={255,128,0},
+      smooth=Smooth.None));
+  connect(sunblind.Rad_out, solarRadAdapter.solarRad_in) annotation (Line(
+      points={{-1,73},{3.5,73},{3.5,72},{9,72}},
+      color={255,128,0},
+      smooth=Smooth.None));
+  connect(window_shortwave_rad_sum.solarRad_out, reducedModel.solarRad_in)
+    annotation (Line(
+      points={{52.9,73},{56,73},{56,58},{49.34,58},{49.34,44.86}},
       color={0,0,127},
       smooth=Smooth.None));
   annotation(Diagram(coordinateSystem(preserveAspectRatio=false,   extent={{-100,

--- a/AixLib/Building/LowOrder/Examples/Validation/VDI6007/Star/TestCase_1.mo
+++ b/AixLib/Building/LowOrder/Examples/Validation/VDI6007/Star/TestCase_1.mo
@@ -39,12 +39,12 @@ equation
           {10.54,-40},{10.54,1.7}},                                                                                        color = {0, 0, 127}, smooth = Smooth.None));
   connect(machinesConvective.port, reducedModel.internalGainsConv) annotation(Line(points={{12,-76},
           {20.4,-76},{20.4,1.7}},                                                                                                  color = {191, 0, 0}, smooth = Smooth.None));
-  connect(solarRadiation.y, reducedModel.u1) annotation (Line(
+  connect(solarRadiation.y, reducedModel.solarRad_in) annotation (Line(
       points={{-25,72},{9.18,72},{9.18,32.98}},
       color={0,0,127},
       smooth=Smooth.None));
-  annotation(Diagram(coordinateSystem(preserveAspectRatio = false,
-             extent = {{-100, -100}, {100, 100}}), graphics),
+  annotation(Diagram(coordinateSystem(preserveAspectRatio=false,
+             extent={{-100,-100},{100,100}}),      graphics),
              experiment(StopTime = 5.184e+006, Interval = 3600),
              __Dymola_Commands(file=
                                "modelica://AixLib/Resources/Scripts/Dymola/Building/LowOrder/Examples/Validation/Star/TestCase_1.mos"

--- a/AixLib/Building/LowOrder/Examples/Validation/VDI6007/Star/TestCase_10.mo
+++ b/AixLib/Building/LowOrder/Examples/Validation/VDI6007/Star/TestCase_10.mo
@@ -57,8 +57,6 @@ equation
   connect(innerLoads.y[2], personsConvective.Q_flow) annotation(Line(points = {{-27, -62}, {20, -62}}, color = {0, 0, 127}, smooth = Smooth.None));
   connect(innerLoads.y[1], personsRadiative.Q_flow) annotation(Line(points = {{-27, -62}, {-8, -62}, {-8, -90}, {20, -90}}, color = {0, 0, 127}, smooth = Smooth.None));
   connect(personsRadiative.port, HeatTorStar.Therm) annotation(Line(points = {{40, -90}, {56.8, -90}}, color = {191, 0, 0}, smooth = Smooth.None));
-  connect(Quelle_Fenster.solarRad_out,sunblind. Rad_In) annotation(Line(points={{-31,82},
-          {-19,82}},                                                                                     color = {255, 128, 0}, smooth = Smooth.None));
   connect(wallRad.y,multiplex5_1. u1[1]) annotation(Line(points={{-115.5,55},{
           -104,55},{-104,64},{-86,64}},                                                                              color = {0, 0, 127}, smooth = Smooth.None));
   connect(wallRad.y,multiplex5_1. u2[1]) annotation(Line(points={{-115.5,55},{
@@ -124,10 +122,6 @@ equation
       points={{-65,82},{-58,82},{-58,75},{-49,75}},
       color={0,0,127},
       smooth=Smooth.None));
-  connect(rad_weighted_sum.solarRad_out, reducedModel.u1) annotation (Line(
-      points={{47,82},{46,82},{46,98},{62.96,98},{62.96,90.5}},
-      color={0,0,127},
-      smooth=Smooth.None));
   connect(Quelle_Wand.solarRad_out, solarRadAdapter1.solarRad_in) annotation (
       Line(
       points={{-39,54},{-39,54}},
@@ -138,13 +132,22 @@ equation
       points={{-20,54},{-20,25.6},{-18.5,25.6}},
       color={0,0,127},
       smooth=Smooth.None));
-  connect(sunblind.Rad_Out, solarRadAdapter2.solarRad_in) annotation (Line(
-      points={{-1,82},{3,82}},
-      color={255,128,0},
-      smooth=Smooth.None));
   connect(solarRadAdapter2.solarRad_out, rad_weighted_sum.solarRad_in)
     annotation (Line(
       points={{22,82},{29,82}},
+      color={0,0,127},
+      smooth=Smooth.None));
+  connect(Quelle_Fenster.solarRad_out, sunblind.Rad_in) annotation (Line(
+      points={{-31,82},{-19,82}},
+      color={255,128,0},
+      smooth=Smooth.None));
+  connect(sunblind.Rad_out, solarRadAdapter2.solarRad_in) annotation (Line(
+      points={{-1,82},{3,82}},
+      color={255,128,0},
+      smooth=Smooth.None));
+  connect(rad_weighted_sum.solarRad_out, reducedModel.solarRad_in) annotation (
+      Line(
+      points={{47,82},{52,82},{52,98},{62.96,98},{62.96,90.5}},
       color={0,0,127},
       smooth=Smooth.None));
   annotation(Diagram(coordinateSystem(preserveAspectRatio=false,

--- a/AixLib/Building/LowOrder/Examples/Validation/VDI6007/Star/TestCase_11.mo
+++ b/AixLib/Building/LowOrder/Examples/Validation/VDI6007/Star/TestCase_11.mo
@@ -72,8 +72,8 @@ equation
       pattern=LinePattern.None,
       smooth=Smooth.None));
   connect(cooler.heatCoolRoom, reducedModel.heatConvInnerwall.port_b);
-  connect(solarRadiation.y, reducedModel.u1) annotation (Line(
-      points={{-25,72},{73.18,72},{73.18,74.8}},
+  connect(solarRadiation.y, reducedModel.solarRad_in) annotation (Line(
+      points={{-25,72},{62,72},{62,84},{73.18,84},{73.18,74.8}},
       color={0,0,127},
       smooth=Smooth.None));
   annotation(experiment(StopTime = 5.184e+006, Interval = 3600),

--- a/AixLib/Building/LowOrder/Examples/Validation/VDI6007/Star/TestCase_12.mo
+++ b/AixLib/Building/LowOrder/Examples/Validation/VDI6007/Star/TestCase_12.mo
@@ -65,8 +65,6 @@ equation
       points={{-39,-6},{10,-6},{10,-4},{64.54,-4},{64.54,32}},
       color={0,0,127},
       smooth=Smooth.None));
-  connect(Quelle_Fenster.solarRad_out,sunblind. Rad_In) annotation(Line(points={{-25,92},
-          {-13,92}},                                                                                     color = {255, 128, 0}, smooth = Smooth.None));
   connect(windowRad.y, Quelle_Fenster.I) annotation (Line(
       points={{-51,92},{-48,92},{-48,100.9},{-42.9,100.9}},
       color={0,0,127},
@@ -87,18 +85,23 @@ equation
       points={{-51,92},{-48,92},{-48,85},{-43,85}},
       color={0,0,127},
       smooth=Smooth.None));
-  connect(rad_weighted_sum.solarRad_out, reducedModel.u1) annotation (Line(
-      points={{59,92},{66,92},{66,90},{63.18,90},{63.18,68.8}},
-      color={0,0,127},
-      smooth=Smooth.None));
   connect(solarRadAdapter2.solarRad_out, rad_weighted_sum.solarRad_in)
     annotation (Line(
       points={{34,92},{41,92}},
       color={0,0,127},
       smooth=Smooth.None));
-  connect(solarRadAdapter2.solarRad_in, sunblind.Rad_Out) annotation (Line(
-      points={{15,92},{5,92}},
+  connect(Quelle_Fenster.solarRad_out, sunblind.Rad_in) annotation (Line(
+      points={{-25,92},{-13,92}},
       color={255,128,0},
+      smooth=Smooth.None));
+  connect(sunblind.Rad_out, solarRadAdapter2.solarRad_in) annotation (Line(
+      points={{5,92},{15,92}},
+      color={255,128,0},
+      smooth=Smooth.None));
+  connect(rad_weighted_sum.solarRad_out, reducedModel.solarRad_in) annotation (
+      Line(
+      points={{59,92},{63.18,92},{63.18,68.8}},
+      color={0,0,127},
       smooth=Smooth.None));
   annotation(Diagram(coordinateSystem(preserveAspectRatio=false,
              extent={{-100,-100},{100,100}}),

--- a/AixLib/Building/LowOrder/Examples/Validation/VDI6007/Star/TestCase_2.mo
+++ b/AixLib/Building/LowOrder/Examples/Validation/VDI6007/Star/TestCase_2.mo
@@ -40,12 +40,12 @@ equation
           {20,-30},{20,11.7},{22.54,11.7}},                                                                                            color = {0, 0, 127}, smooth = Smooth.None));
   connect(HeatToStar.Star, reducedModel.internalGainsRad) annotation(Line(points={{70,
           -28.9},{70,-18},{41.75,-18},{41.75,11.7}},                                                                                      color = {95, 95, 95}, pattern = LinePattern.None, smooth = Smooth.None));
-  connect(solarRadiation.y, reducedModel.u1) annotation (Line(
+  connect(solarRadiation.y, reducedModel.solarRad_in) annotation (Line(
       points={{-25,72},{21.18,72},{21.18,42.98}},
       color={0,0,127},
       smooth=Smooth.None));
-  annotation(Diagram(coordinateSystem(preserveAspectRatio = false,
-             extent = {{-100, -100}, {100, 100}}), graphics),
+  annotation(Diagram(coordinateSystem(preserveAspectRatio=false,
+             extent={{-100,-100},{100,100}}),      graphics),
              experiment(StopTime = 5.184e+006, Interval = 3600),
              __Dymola_Commands(file=
                                "modelica://AixLib/Resources/Scripts/Dymola/Building/LowOrder/Examples/Validation/Star/TestCase_2.mos"

--- a/AixLib/Building/LowOrder/Examples/Validation/VDI6007/Star/TestCase_3.mo
+++ b/AixLib/Building/LowOrder/Examples/Validation/VDI6007/Star/TestCase_3.mo
@@ -39,7 +39,7 @@ equation
           {22,-30},{22,11.7},{22.54,11.7}},                                                                                            color = {0, 0, 127}, smooth = Smooth.None));
   connect(machinesConvective.port, reducedModel.internalGainsConv) annotation(Line(points={{24,-58},
           {32.4,-58},{32.4,11.7}},                                                                                                  color = {191, 0, 0}, smooth = Smooth.None));
-  connect(solarRadiation.y, reducedModel.u1) annotation (Line(
+  connect(solarRadiation.y, reducedModel.solarRad_in) annotation (Line(
       points={{-25,72},{21.18,72},{21.18,42.98}},
       color={0,0,127},
       smooth=Smooth.None));
@@ -66,6 +66,6 @@ equation
                                "modelica://AixLib/Resources/Scripts/Dymola/Building/LowOrder/Examples/Validation/Star/TestCase_3.mos"
         "Simulate and plot"),
             __Dymola_experimentSetupOutput(events = false),
-            Diagram(coordinateSystem(preserveAspectRatio = false,
-            extent = {{-100, -100}, {100, 100}}), graphics));
+            Diagram(coordinateSystem(preserveAspectRatio=false,
+            extent={{-100,-100},{100,100}}),      graphics));
 end TestCase_3;

--- a/AixLib/Building/LowOrder/Examples/Validation/VDI6007/Star/TestCase_4.mo
+++ b/AixLib/Building/LowOrder/Examples/Validation/VDI6007/Star/TestCase_4.mo
@@ -55,7 +55,7 @@ equation
           {18,-30},{18,11.7},{20.54,11.7}},                                                                                            color = {0, 0, 127}, smooth = Smooth.None));
   connect(HeatToStar.Star, reducedModel.internalGainsRad) annotation(Line(points={{55.1,
           -58},{58,-58},{58,-10},{39.75,-10},{39.75,11.7}},                                                                                          color = {95, 95, 95}, pattern = LinePattern.None, smooth = Smooth.None));
-  connect(solarRadiation.y, reducedModel.u1) annotation (Line(
+  connect(solarRadiation.y, reducedModel.solarRad_in) annotation (Line(
       points={{-25,72},{19.18,72},{19.18,42.98}},
       color={0,0,127},
       smooth=Smooth.None));
@@ -76,8 +76,8 @@ equation
  <p>Variable path: <code>reducedModel.airload.T</code></p>
  <p><br><br>All values are given in the VDI 6007-1.</p>
  <p>Same Test Case exists in VDI 6020.</p>
- </html>"), Diagram(coordinateSystem(preserveAspectRatio = false,
-             extent = {{-100, -100}, {100, 100}}), graphics),
+ </html>"), Diagram(coordinateSystem(preserveAspectRatio=false,
+             extent={{-100,-100},{100,100}}),      graphics),
              Icon(graphics),
              experiment(StopTime = 5.184e+006, Interval = 3600),
              __Dymola_Commands(file=

--- a/AixLib/Building/LowOrder/Examples/Validation/VDI6007/Star/TestCase_5.mo
+++ b/AixLib/Building/LowOrder/Examples/Validation/VDI6007/Star/TestCase_5.mo
@@ -46,8 +46,8 @@ model TestCase_5
     annotation (Placement(transformation(extent={{-84,78},{-64,98}})));
   Utilities.Sources.PrescribedSolarRad PrescribedSolarRad(n = 5) annotation(Placement(transformation(extent={{-50,78},
             {-30,98}})));
-  Components.Weather.Sunblind sunblind(n = 5, gsunblind = {0, 0, 0.15, 0, 0}) annotation(Placement(transformation(extent={{-20,77},
-            {0,97}})));
+  Components.Weather.Sunblind sunblind(n = 5, gsunblind = {0, 0, 0.15, 0, 0}) annotation(Placement(transformation(extent={{-24,77},
+            {-4,97}})));
   BaseClasses.SolarRadWeightedSum                   SolarRadWeightedSum(n = 5, weightfactors = {0, 0, 7, 0, 0}) annotation(Placement(transformation(extent={{28,78},
             {48,98}})));
   BaseClasses.SolarRadAdapter solarRadAdapter[5]
@@ -70,12 +70,6 @@ equation
   connect(innerLoads.y[3], machinesConvective.Q_flow) annotation(Line(points = {{-37, -62}, {-18, -62}, {-18, -42}, {10, -42}}, color = {0, 0, 127}, smooth = Smooth.None));
   connect(innerLoads.y[2], personsConvective.Q_flow) annotation(Line(points = {{-37, -62}, {10, -62}}, color = {0, 0, 127}, smooth = Smooth.None));
   connect(innerLoads.y[1], personsRadiative.Q_flow) annotation(Line(points = {{-37, -62}, {-18, -62}, {-18, -90}, {10, -90}}, color = {0, 0, 127}, smooth = Smooth.None));
-  connect(PrescribedSolarRad.solarRad_out,sunblind. Rad_In) annotation(Line(points={{-31,88},
-          {-19,88}},                                                                                         color = {255, 128, 0}, smooth = Smooth.None));
-  connect(SolarRadWeightedSum.solarRad_out, reducedModel.u1) annotation (Line(
-      points={{47,88},{57.18,88},{57.18,64.8}},
-      color={0,0,127},
-      smooth=Smooth.None));
   connect(windowRad.y, PrescribedSolarRad.I) annotation (Line(
       points={{-63,88},{-56,88},{-56,96.9},{-48.9,96.9}},
       color={0,0,127},
@@ -101,12 +95,21 @@ equation
       points={{22,88},{29,88}},
       color={0,0,127},
       smooth=Smooth.None));
-  connect(sunblind.Rad_Out, solarRadAdapter.solarRad_in) annotation (Line(
-      points={{-1,88},{3,88}},
+  connect(PrescribedSolarRad.solarRad_out, sunblind.Rad_in) annotation (Line(
+      points={{-31,88},{-23,88}},
       color={255,128,0},
       smooth=Smooth.None));
-  annotation(Diagram(coordinateSystem(preserveAspectRatio = false,
-             extent = {{-100, -100}, {100, 100}}), graphics),
+  connect(sunblind.Rad_out, solarRadAdapter.solarRad_in) annotation (Line(
+      points={{-5,88},{3,88}},
+      color={255,128,0},
+      smooth=Smooth.None));
+  connect(SolarRadWeightedSum.solarRad_out, reducedModel.solarRad_in)
+    annotation (Line(
+      points={{47,88},{57.18,88},{57.18,64.8}},
+      color={0,0,127},
+      smooth=Smooth.None));
+  annotation(Diagram(coordinateSystem(preserveAspectRatio=false,
+             extent={{-100,-100},{100,100}}),      graphics),
              experiment(StopTime=5.184e+006, Interval=3600, __Dymola_Algorithm="Lsodar"),
              __Dymola_Commands(file=
                                "modelica://AixLib/Resources/Scripts/Dymola/Building/LowOrder/Examples/Validation/Star/TestCase_5.mos"

--- a/AixLib/Building/LowOrder/Examples/Validation/VDI6007/Star/TestCase_6.mo
+++ b/AixLib/Building/LowOrder/Examples/Validation/VDI6007/Star/TestCase_6.mo
@@ -46,12 +46,12 @@ equation
   connect(setTemp.y[1], varTemp.T) annotation(Line(points = {{-41, -28}, {-8, -28}}, color = {0, 0, 127}, smooth = Smooth.None));
   connect(heatFlowSensor.port_b, reducedModel.internalGainsConv) annotation(Line(points={{44,-28},
           {74.4,-28},{74.4,28}},                                                                                                color = {191, 0, 0}, smooth = Smooth.None));
-  connect(solarRadiation.y, reducedModel.u1) annotation (Line(
+  connect(solarRadiation.y, reducedModel.solarRad_in) annotation (Line(
       points={{-25,72},{63.18,72},{63.18,64.8}},
       color={0,0,127},
       smooth=Smooth.None));
-  annotation(Diagram(coordinateSystem(preserveAspectRatio = false,
-              extent = {{-100, -100}, {100, 100}}), graphics),
+  annotation(Diagram(coordinateSystem(preserveAspectRatio=false,
+              extent={{-100,-100},{100,100}}),      graphics),
               experiment(StopTime = 5.184e+006, Interval = 3600, __Dymola_Algorithm = "Lsodar"),
               __Dymola_Commands(file=
                                "modelica://AixLib/Resources/Scripts/Dymola/Building/LowOrder/Examples/Validation/Star/TestCase_6.mos"

--- a/AixLib/Building/LowOrder/Examples/Validation/VDI6007/Star/TestCase_7.mo
+++ b/AixLib/Building/LowOrder/Examples/Validation/VDI6007/Star/TestCase_7.mo
@@ -47,12 +47,12 @@ equation
           -10},{54.54,-10},{54.54,40}},                                                                                      color = {0, 0, 127}, smooth = Smooth.None));
   connect(HeatToStar.Star, reducedModel.internalGainsRad) annotation(Line(points={{59.1,
           -89},{72,-89},{72,40},{73.75,40}},                                                                                        color = {95, 95, 95}, pattern = LinePattern.None, smooth = Smooth.None));
-  connect(solarRadiation.y, reducedModel.u1) annotation (Line(
-      points={{-25,72},{53.18,72},{53.18,76.8}},
+  connect(solarRadiation.y, reducedModel.solarRad_in) annotation (Line(
+      points={{-25,72},{38,72},{38,86},{53.18,86},{53.18,76.8}},
       color={0,0,127},
       smooth=Smooth.None));
-  annotation(Diagram(coordinateSystem(preserveAspectRatio = false,
-             extent = {{-100, -100}, {100, 100}}), graphics),
+  annotation(Diagram(coordinateSystem(preserveAspectRatio=false,
+             extent={{-100,-100},{100,100}}),      graphics),
              experiment(StopTime = 5.184e+006, Interval = 3600, Algorithm = "Lsodar"),
              __Dymola_Commands(file=
                                "modelica://AixLib/Resources/Scripts/Dymola/Building/LowOrder/Examples/Validation/Star/TestCase_7.mos"

--- a/AixLib/Building/LowOrder/Examples/Validation/VDI6007/Star/TestCase_8.mo
+++ b/AixLib/Building/LowOrder/Examples/Validation/VDI6007/Star/TestCase_8.mo
@@ -68,8 +68,6 @@ equation
   connect(innerLoads.y[2], personsConvective.Q_flow) annotation(Line(points = {{-41, -60}, {6, -60}}, color = {0, 0, 127}, smooth = Smooth.None));
   connect(innerLoads.y[1], personsRadiative.Q_flow) annotation(Line(points = {{-41, -60}, {-22, -60}, {-22, -88}, {6, -88}}, color = {0, 0, 127}, smooth = Smooth.None));
   connect(personsRadiative.port, HeatTorStar.Therm) annotation(Line(points = {{26, -88}, {42.8, -88}}, color = {191, 0, 0}, smooth = Smooth.None));
-  connect(Quelle_Fenster.solarRad_out,sunblind. Rad_In) annotation(Line(points={{-31,88},
-          {-19,88}},                                                                                     color = {255, 128, 0}, smooth = Smooth.None));
   connect(sunblind.sunblindonoff,eqAirTemp. sunblindsig) annotation(Line(points={{-10,78},
           {-4,78},{-4,58},{4,58}},                                                                                             color = {0, 0, 127}, smooth = Smooth.None));
   connect(infiltrationTemp.y, reducedModel.ventilationTemperature) annotation(Line(points={{36.5,29},
@@ -81,14 +79,6 @@ equation
   connect(eqAirTemp.equalAirTemp, reducedModel.equalAirTemp) annotation (Line(
       points={{13.8,44.4},{24,44.4},{24,44},{36,44},{36,46.8},{51.4,46.8}},
       color={191,0,0},
-      smooth=Smooth.None));
-  connect(rad_weighted_sum.solarRad_out, reducedModel.u1) annotation (Line(
-      points={{49,88},{57.18,88},{57.18,64.8}},
-      color={0,0,127},
-      smooth=Smooth.None));
-  connect(sunblind.Rad_Out, solarRadAdapter.solarRad_in) annotation (Line(
-      points={{-1,88},{9,88}},
-      color={255,128,0},
       smooth=Smooth.None));
   connect(rad_weighted_sum.solarRad_in, solarRadAdapter.solarRad_out)
     annotation (Line(
@@ -143,6 +133,19 @@ equation
   connect(eqAirTemp.solarRad_in, solarRadAdapter1.solarRad_out) annotation (
       Line(
       points={{-4.5,55.6},{-6,55.6},{-6,56},{-8,56}},
+      color={0,0,127},
+      smooth=Smooth.None));
+  connect(Quelle_Fenster.solarRad_out, sunblind.Rad_in) annotation (Line(
+      points={{-31,88},{-19,88}},
+      color={255,128,0},
+      smooth=Smooth.None));
+  connect(sunblind.Rad_out, solarRadAdapter.solarRad_in) annotation (Line(
+      points={{-1,88},{9,88}},
+      color={255,128,0},
+      smooth=Smooth.None));
+  connect(rad_weighted_sum.solarRad_out, reducedModel.solarRad_in) annotation (
+      Line(
+      points={{49,88},{57.18,88},{57.18,64.8}},
       color={0,0,127},
       smooth=Smooth.None));
   annotation(Diagram(coordinateSystem(preserveAspectRatio=false,

--- a/AixLib/Building/LowOrder/Examples/Validation/VDI6007/Star/TestCase_9.mo
+++ b/AixLib/Building/LowOrder/Examples/Validation/VDI6007/Star/TestCase_9.mo
@@ -76,8 +76,6 @@ equation
   connect(personsRadiative.port, HeatTorStar.Therm) annotation(Line(points = {{22, -86}, {38.8, -86}}, color = {191, 0, 0}, smooth = Smooth.None));
   connect(sunblind.sunblindonoff,eqAirTemp. sunblindsig) annotation(Line(points={{-14,63},
           {-14,22},{-12,22}},                                                                             color = {0, 0, 127}, smooth = Smooth.None));
-  connect(varRad3.solarRad_out,sunblind. Rad_In) annotation(Line(points={{-43,73},
-          {-23,73}},                                                                              color = {255, 128, 0}, smooth = Smooth.None));
   connect(outdoorTemp.y,deMultiplex3_1. u) annotation(Line(points={{-77.3,10},{
           -73.2,10}},                                                                           color = {0, 0, 127}, smooth = Smooth.None));
   connect(deMultiplex3_1.y1[1],from_degC. u) annotation(Line(points={{-59.4,
@@ -130,10 +128,6 @@ equation
       points={{-93.3,33},{-78.65,33},{-78.65,26},{-73,26}},
       color={0,0,127},
       smooth=Smooth.None));
-  connect(sunblind.Rad_Out, solarRadAdapter.solarRad_in) annotation (Line(
-      points={{-5,73},{0,73},{0,72},{5,72}},
-      color={255,128,0},
-      smooth=Smooth.None));
   connect(varRad1.solarRad_out, solarRadAdapter1.solarRad_in) annotation (Line(
       points={{-55,33},{-55,34},{-47,34}},
       color={255,128,0},
@@ -148,11 +142,6 @@ equation
       points={{22.7,16},{32,16},{32,17.88},{42.2,17.88}},
       color={0,0,127},
       smooth=Smooth.None));
-  connect(window_shortwave_rad_sum.solarRad_out, reducedModel.u1) annotation (
-      Line(
-      points={{48.9,71},{48.9,57.5},{49.34,57.5},{49.34,44.86}},
-      color={0,0,127},
-      smooth=Smooth.None));
   connect(window_shortwave_rad_sum.solarRad_in, solarRadAdapter.solarRad_out)
     annotation (Line(
       points={{29.1,71},{26,71},{26,72},{24,72}},
@@ -160,6 +149,19 @@ equation
       smooth=Smooth.None));
   connect(deMultiplex3_1.y3, multiplex3_1.u3) annotation (Line(
       points={{-59.4,5.8},{-50.7,5.8},{-50.7,5.8},{-42.2,5.8}},
+      color={0,0,127},
+      smooth=Smooth.None));
+  connect(varRad3.solarRad_out, sunblind.Rad_in) annotation (Line(
+      points={{-43,73},{-32.5,73},{-32.5,73},{-23,73}},
+      color={255,128,0},
+      smooth=Smooth.None));
+  connect(sunblind.Rad_out, solarRadAdapter.solarRad_in) annotation (Line(
+      points={{-5,73},{-0.5,73},{-0.5,72},{5,72}},
+      color={255,128,0},
+      smooth=Smooth.None));
+  connect(window_shortwave_rad_sum.solarRad_out, reducedModel.solarRad_in)
+    annotation (Line(
+      points={{48.9,71},{52,71},{52,58},{49.34,58},{49.34,44.86}},
       color={0,0,127},
       smooth=Smooth.None));
   annotation(Diagram(coordinateSystem(preserveAspectRatio=false,

--- a/AixLib/Building/LowOrder/Examples/improvedLOMExample.mo
+++ b/AixLib/Building/LowOrder/Examples/improvedLOMExample.mo
@@ -39,8 +39,8 @@ model improvedLOMExample
   Utilities.HeatTransfer.HeatToStar HeatTorStar(A = 2) annotation(Placement(transformation(extent={{52,-88},
             {72,-68}})));
   AixLib.Building.Components.Weather.Sunblind
-                              sunblind(n = 5, gsunblind = {0, 0, 0.15, 0.15, 0}) annotation(Placement(transformation(extent={{-24,59},
-            {-4,79}})));
+                              sunblind(n = 5, gsunblind = {0, 0, 0.15, 0.15, 0}) annotation(Placement(transformation(extent={{-42,59},
+            {-22,79}})));
   AixLib.Building.LowOrder.BaseClasses.SolarRadWeightedSum solarRadWeightedSum(
       weightfactors={0,0,7,7,0}, n=5)
     annotation (Placement(transformation(extent={{4,55},{38,85}})));
@@ -65,11 +65,15 @@ model improvedLOMExample
     annotation (Placement(transformation(extent={{-20,-54},{-10,-44}})));
   Modelica.Blocks.Math.Gain gain2(k=0.4)
     annotation (Placement(transformation(extent={{-20,-82},{-12,-74}})));
+  replaceable
+    AixLib.Building.Components.WindowsDoors.BaseClasses.CorrectionSolarGain.NoCorG
+    partialCorG(n=5) constrainedby
+    Components.WindowsDoors.BaseClasses.CorrectionSolarGain.PartialCorG
+    annotation (Placement(transformation(extent={{-14,63},{0,77}})));
+  AixLib.Building.LowOrder.BaseClasses.SolarRadAdapter
+                  solarRadAdapter[5]
+    annotation (Placement(transformation(extent={{-98,22},{-78,42}})));
 equation
-  connect(sunblind.Rad_Out, solarRadWeightedSum.solarRad_in) annotation (Line(
-      points={{-5,70},{5.7,70}},
-      color={255,128,0},
-      smooth=Smooth.None));
   connect(personsRadiative.port,HeatTorStar. Therm) annotation(Line(points={{36,-78},
           {52.8,-78}},                                                                                 color = {191, 0, 0}, smooth = Smooth.None));
   connect(partialEqAirTemp.equalAirTemp, reducedOrderModel.equalAirTemp)
@@ -100,12 +104,12 @@ equation
       smooth=Smooth.None));
   connect(solarRadWeightedSum.solarRad_out, reducedOrderModel.solarRad_in)
     annotation (Line(
-      points={{36.3,70},{54.2,70},{54.2,51.15}},
+      points={{36.3,70},{53.18,70},{53.18,50.98}},
       color={255,128,0},
       smooth=Smooth.None));
   connect(sunblind.sunblindonoff, partialEqAirTemp.sunblindsig) annotation (
       Line(
-      points={{-14,60},{-14,52},{-46,52},{-46,34}},
+      points={{-32,60},{-32,52},{-46,52},{-46,34}},
       color={0,0,127},
       smooth=Smooth.None));
   connect(weather.WeatherDataVector, partialEqAirTemp.weatherData) annotation (
@@ -113,14 +117,9 @@ equation
       points={{-75.1,67},{-75.1,26},{-54,26}},
       color={0,0,127},
       smooth=Smooth.None));
-  connect(weather.SolarRadiation_OrientedSurfaces, partialEqAirTemp.solarRad_in)
-    annotation (Line(
-      points={{-82.8,67},{-82.8,31.6},{-54.5,31.6}},
-      color={255,128,0},
-      smooth=Smooth.None));
-  connect(weather.SolarRadiation_OrientedSurfaces, sunblind.Rad_In) annotation (
+  connect(weather.SolarRadiation_OrientedSurfaces, sunblind.Rad_in) annotation (
      Line(
-      points={{-82.8,67},{-82.8,58},{-46,58},{-46,70},{-23,70}},
+      points={{-82.8,67},{-82.8,58},{-46,58},{-46,70},{-41,70}},
       color={255,128,0},
       smooth=Smooth.None));
   connect(weather.WeatherDataVector[1], reducedOrderModel.ventilationTemperature)
@@ -158,6 +157,25 @@ equation
       color={191,0,0},
       smooth=Smooth.None));
 
+  connect(sunblind.Rad_out, partialCorG.SR_input) annotation (Line(
+      points={{-23,70},{-18,70},{-18,69.93},{-13.86,69.93}},
+      color={255,128,0},
+      smooth=Smooth.None));
+  connect(partialCorG.solarRadWinTrans, solarRadWeightedSum.solarRad_in)
+    annotation (Line(
+      points={{-0.7,70},{5.7,70}},
+      color={0,0,127},
+      smooth=Smooth.None));
+  connect(weather.SolarRadiation_OrientedSurfaces, solarRadAdapter.solarRad_in)
+    annotation (Line(
+      points={{-82.8,67},{-82.8,50.5},{-97,50.5},{-97,32}},
+      color={255,128,0},
+      smooth=Smooth.None));
+  connect(solarRadAdapter.solarRad_out, partialEqAirTemp.solarRad_in)
+    annotation (Line(
+      points={{-78,32},{-80,32},{-80,31.6},{-54.5,31.6}},
+      color={0,0,127},
+      smooth=Smooth.None));
   annotation (Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,
             -100},{100,100}}), graphics),
     experiment(StopTime=86400, Interval=3600),

--- a/AixLib/Building/LowOrder/Examples/improvedLOMExample.mo
+++ b/AixLib/Building/LowOrder/Examples/improvedLOMExample.mo
@@ -182,6 +182,9 @@ equation
     __Dymola_experimentSetupOutput,
     Documentation(revisions="<html>
 <ul>
+<li><i>June 2015,&nbsp;</i> by Moritz Lauster:<br>Debugged due to name changes in partialReducedOrderModel</li>
+</ul>
+<ul>
 <li>October 2014, Peter Remmen:</li>
 </ul>
 <p>implemented</p>


### PR DESCRIPTION
…from u1 to solRad_in

changed name of solar radiation input and output of Sunblind.moto solRad_in and solRad_out
fixed validation cases and improvedLOMExample.mo due to changed naming and changed handling of solar radiation (in case of improvedLOMExample.mo)