### PR TITLE
Issue #101 tried to make naming more consitent:

### DIFF
--- a/AixLib/Building/HighOrder/Examples/Appartment_VoWo.mo
+++ b/AixLib/Building/HighOrder/Examples/Appartment_VoWo.mo
@@ -34,35 +34,35 @@ model Appartment_VoWo "Simulation of 1 apartment "
   Modelica.Blocks.Sources.Constant Source_TseBoiler(k = 273.15 + 55) annotation(Placement(transformation(extent = {{-86, -96}, {-72, -82}})));
   output Real Ta = combinedWeather.AirTemp;
   // Livingroom
-  output Real airTLiving = VoWoWSchV1984.Appartment.Livingroom.airload.T;
-  output Real radPowerLiConv = -VoWoWSchV1984.Hydraulic.Con_Livingroom.Q_flow;
-  output Real radPowerLiRad = -VoWoWSchV1984.Hydraulic.Rad_Livingroom.Q_flow;
-  output Real travelHVLi = VoWoWSchV1984.Hydraulic.valve_livingroom.opening;
-  output Real massFlowLi = VoWoWSchV1984.Hydraulic.valve_livingroom.port_a.m_flow;
+  output Real airTLi = VoWoWSchV1984.Appartment.Livingroom.airload.T;
+  output Real radPowerLiConv = -VoWoWSchV1984.Hydraulic.convLi.Q_flow;
+  output Real radPowerLiRad = -VoWoWSchV1984.Hydraulic.radLi.Q_flow;
+  output Real travelHVLi = VoWoWSchV1984.Hydraulic.valveLi.opening;
+  output Real massFlowLi = VoWoWSchV1984.Hydraulic.valveLi.port_a.m_flow;
   // Bath
-  output Real airTBath = VoWoWSchV1984.Appartment.Bathroom.airload.T;
-  output Real radPowerBConv = -VoWoWSchV1984.Hydraulic.Con_bath.Q_flow;
-  output Real radPowerBRad = -VoWoWSchV1984.Hydraulic.Rad_bath.Q_flow;
-  output Real travelHVB = VoWoWSchV1984.Hydraulic.valve_bath.opening;
-  output Real massFlowB = VoWoWSchV1984.Hydraulic.valve_bath.port_a.m_flow;
+  output Real airTBa = VoWoWSchV1984.Appartment.Bathroom.airload.T;
+  output Real radPowerBaConv = -VoWoWSchV1984.Hydraulic.convBa.Q_flow;
+  output Real radPowerBaRad = -VoWoWSchV1984.Hydraulic.radBa.Q_flow;
+  output Real travelHVBa = VoWoWSchV1984.Hydraulic.valveBa.opening;
+  output Real massFlowBa = VoWoWSchV1984.Hydraulic.valveBa.port_a.m_flow;
   // Bedroom
-  output Real airTBedromm = VoWoWSchV1984.Appartment.Bedroom.airload.T;
-  output Real radPowerBrConv = -VoWoWSchV1984.Hydraulic.Con_bedroom.Q_flow;
-  output Real radPowerBrRad = -VoWoWSchV1984.Hydraulic.Rad_bedroom.Q_flow;
-  output Real travelHVBr = VoWoWSchV1984.Hydraulic.valve_bedroom.opening;
-  output Real massFlowBr = VoWoWSchV1984.Hydraulic.valve_bedroom.port_a.m_flow;
+  output Real airTBe = VoWoWSchV1984.Appartment.Bedroom.airload.T;
+  output Real radPowerBeConv = -VoWoWSchV1984.Hydraulic.convBe.Q_flow;
+  output Real radPowerBeRad = -VoWoWSchV1984.Hydraulic.radBe.Q_flow;
+  output Real travelHVBe = VoWoWSchV1984.Hydraulic.valveBe.opening;
+  output Real massFlowBe = VoWoWSchV1984.Hydraulic.valveBe.port_a.m_flow;
   // Children
-  output Real airTChildren = VoWoWSchV1984.Appartment.Children.airload.T;
-  output Real radPowerChConv = -VoWoWSchV1984.Hydraulic.Con_children.Q_flow;
-  output Real radPowerChRad = -VoWoWSchV1984.Hydraulic.Rad_children.Q_flow;
-  output Real travelHVCh = VoWoWSchV1984.Hydraulic.valve_children.opening;
-  output Real massFlowCh = VoWoWSchV1984.Hydraulic.valve_children.port_a.m_flow;
+  output Real airTCh = VoWoWSchV1984.Appartment.Children.airload.T;
+  output Real radPowerChConv = -VoWoWSchV1984.Hydraulic.convCh.Q_flow;
+  output Real radPowerChRad = -VoWoWSchV1984.Hydraulic.radCh.Q_flow;
+  output Real travelHVCh = VoWoWSchV1984.Hydraulic.valveCh.opening;
+  output Real massFlowCh = VoWoWSchV1984.Hydraulic.valveCh.port_a.m_flow;
   // Kitchen
-  output Real airTKitchen = VoWoWSchV1984.Appartment.Kitchen.airload.T;
-  output Real radPowerKitConv = -VoWoWSchV1984.Hydraulic.Con_kitchen.Q_flow;
-  output Real radPowerKitRad = -VoWoWSchV1984.Hydraulic.Rad_kitchen.Q_flow;
-  output Real travelHVKit = VoWoWSchV1984.Hydraulic.valve_kitchen.opening;
-  output Real massFlowKit = VoWoWSchV1984.Hydraulic.valve_kitchen.port_a.m_flow;
+  output Real airTKi = VoWoWSchV1984.Appartment.Kitchen.airload.T;
+  output Real radPowerKiConv = -VoWoWSchV1984.Hydraulic.convKi.Q_flow;
+  output Real radPowerKiRad = -VoWoWSchV1984.Hydraulic.radKi.Q_flow;
+  output Real travelHVKi = VoWoWSchV1984.Hydraulic.valveKi.opening;
+  output Real massFlowKi = VoWoWSchV1984.Hydraulic.valveKi.port_a.m_flow;
 equation
   connect(Pumpe.port_b, boilerTable.port_a) annotation(Line(points = {{-16, -72}, {-38, -72}, {-38, -76}, {-44, -76}}, color = {0, 127, 255}, smooth = Smooth.None));
   connect(boilerTable.port_b, pipe.port_a) annotation(Line(points = {{-64, -76}, {-74, -76}, {-74, -42}, {-30, -42}}, color = {0, 127, 255}, smooth = Smooth.None));
@@ -102,7 +102,7 @@ equation
       color={0,127,255},
       smooth=Smooth.None));
   annotation(Diagram(coordinateSystem(preserveAspectRatio=false,   extent={{-100,
-            -140},{100,100}}),                                                                           graphics={  Text(extent=  {{-48, -82}, {90, -168}}, lineColor=  {0, 0, 255}, textString=  "Set initial values for iteration variables (list given by translate, usually pressure drops). Rule of thumb: valves 1000 Pa, pipes 100 Pa. Simulation may still work without some of them, but  it gives warning of division by zero at initialization.
+            -140},{100,100}}),                                                                           graphics={  Text(extent = {{-48, -82}, {90, -168}}, lineColor = {0, 0, 255}, textString = "Set initial values for iteration variables (list given by translate, usually pressure drops). Rule of thumb: valves 1000 Pa, pipes 100 Pa. Simulation may still work without some of them, but  it gives warning of division by zero at initialization.
  ")}), experiment(StopTime = 86400, Interval = 60, __Dymola_Algorithm = "Lsodar"), experimentSetupOutput(states = false, derivatives = false, auxiliaries = false, events = false), Documentation(info = "<html>
  <h4><span style=\"color:#008000\">Overview</span></h4>
  <p>Example for setting up a simulation for an appartment.</p>

--- a/AixLib/Building/HighOrder/House/MFD/BuildingAndEnergySystem/OneAppartment_Radiators.mo
+++ b/AixLib/Building/HighOrder/House/MFD/BuildingAndEnergySystem/OneAppartment_Radiators.mo
@@ -130,27 +130,27 @@ equation
           {20,-73.1429},{28.4,-73.1429}},                                                                               color = {0, 127, 255}, smooth = Smooth.None));
   connect(Returnflow, Hydraulic.RETURN) annotation(Line(points={{8,-108},{8,-74},
           {23.2,-74},{23.2,-73.1429}},                                                                                 color = {0, 127, 255}, smooth = Smooth.None));
-  connect(Hydraulic.Rad_Livingroom, Appartment.StarLivingroom) annotation(Line(points={{-20,
+  connect(Hydraulic.radLi, Appartment.StarLivingroom) annotation(Line(points={{-20,
           -30.1429},{-26,-30.1429},{-26,-30},{-34,-30},{-34,0},{-5.61333,0},{
           -5.61333,40.4467}},                                                                                                    color = {0, 0, 0}, smooth = Smooth.None));
-  connect(Hydraulic.Con_Livingroom, Appartment.thermLivingroom) annotation(Line(points={{-19.9,
+  connect(Hydraulic.convLi, Appartment.thermLivingroom) annotation(Line(points={{-19.9,
           -34.4286},{-34,-34.4286},{-34,0},{-6,0},{-6,43.34},{-9.33333,43.34}},                                                                                                   color = {191, 0, 0}, smooth = Smooth.None));
-  connect(Hydraulic.Rad_bedroom, Appartment.StarBedroom) annotation(Line(points={{35.4,
+  connect(Hydraulic.radBe, Appartment.StarBedroom) annotation(Line(points={{35.4,
           -15.7143},{54,-15.7143},{54,0},{-5.61333,0},{-5.61333,36.7267}},                                                                                         color = {0, 0, 0}, smooth = Smooth.None));
-  connect(Hydraulic.Con_bedroom, Appartment.ThermBedroom) annotation(Line(points={{35.6,
+  connect(Hydraulic.convBe, Appartment.ThermBedroom) annotation(Line(points={{35.6,
           -22.5714},{54,-22.5714},{54,0},{-9.74667,0},{-9.74667,36.52}},                                                                                          color = {191, 0, 0}, smooth = Smooth.None));
-  connect(Hydraulic.Rad_children, Appartment.StarChildren) annotation(Line(points={{36,
+  connect(Hydraulic.radCh, Appartment.StarChildren) annotation(Line(points={{36,
           -29.4286},{54,-29.4286},{54,0},{14.64,0},{14.64,45.6133}},                                                                                         color = {0, 0, 0}, smooth = Smooth.None));
-  connect(Hydraulic.Con_children, Appartment.ThermChildren) annotation(Line(points={{35.7,
+  connect(Hydraulic.convCh, Appartment.ThermChildren) annotation(Line(points={{35.7,
           -36.1429},{54,-36.1429},{54,0},{12,0},{12,22},{10.92,22},{10.92,
           45.6133}},                                                                                                    color = {191, 0, 0}, smooth = Smooth.None));
-  connect(Hydraulic.Rad_bath, Appartment.StarBath) annotation(Line(points={{35.6,
+  connect(Hydraulic.radBa, Appartment.StarBath) annotation(Line(points={{35.6,
           -51.4286},{54,-51.4286},{54,0},{2.44667,0},{2.44667,34.8667}},                                                                                   color = {0, 0, 0}, smooth = Smooth.None));
-  connect(Hydraulic.Con_bath, Appartment.ThermBath) annotation(Line(points={{35.7,
+  connect(Hydraulic.convBa, Appartment.ThermBath) annotation(Line(points={{35.7,
           -57.7143},{54,-57.7143},{54,0},{-1.48,0},{-1.48,34.8667}},                                                                                    color = {191, 0, 0}, smooth = Smooth.None));
-  connect(Hydraulic.Rad_kitchen, Appartment.StarKitchen) annotation(Line(points={{-19.5,
+  connect(Hydraulic.radKi, Appartment.StarKitchen) annotation(Line(points={{-19.5,
           -55.4286},{-34,-55.4286},{-34,0},{9.88667,0},{9.88667,31.7667}},                                                                                          color = {0, 0, 0}, smooth = Smooth.None));
-  connect(Hydraulic.Con_kitchen, Appartment.ThermKitchen) annotation(Line(points={{-19.6,
+  connect(Hydraulic.convKi, Appartment.ThermKitchen) annotation(Line(points={{-19.6,
           -60.1429},{-34,-60.1429},{-34,0},{10.92,0},{10.92,36.52}},                                                                                           color = {191, 0, 0}, smooth = Smooth.None));
   connect(Hydraulic.TSet, TSet) annotation(Line(points = {{-13.1, -16}, {-14, -16}, {-14, 0}, {-120, 0}}, color = {0, 0, 127}, smooth = Smooth.None));
   annotation(Diagram(coordinateSystem(preserveAspectRatio=false,   extent={{-120,
@@ -163,5 +163,5 @@ equation
  <ul>
  <li><i>June 19, 2014</i> by Ana Constantin:<br/>Implemented</li>
  </ul>
- </html>"), Icon(coordinateSystem(extent = {{-120, -120}, {100, 120}}, preserveAspectRatio = false), graphics={  Bitmap(extent=  {{-86, 80}, {76, -84}}, fileName=  "modelica://AixLib/Images/House/MFD_FloorPlan_En.PNG")}));
+ </html>"), Icon(coordinateSystem(extent = {{-120, -120}, {100, 120}}, preserveAspectRatio = false), graphics={  Bitmap(extent = {{-86, 80}, {76, -84}}, fileName = "modelica://AixLib/Images/House/MFD_FloorPlan_En.PNG")}));
 end OneAppartment_Radiators;

--- a/AixLib/Building/HighOrder/House/MFD/EnergySystem/OneAppartment/Radiators.mo
+++ b/AixLib/Building/HighOrder/House/MFD/EnergySystem/OneAppartment/Radiators.mo
@@ -32,41 +32,66 @@ model Radiators
   parameter AixLib.DataBase.Radiators.RadiatiorBaseDataDefinition Type_Radiator_Bath = AixLib.DataBase.Radiators.StandardMFD_WSchV1984_OneAppartment.Bathroom() "Bath" annotation(Dialog(group = "Radiators", descriptionLabel = true));
   parameter AixLib.DataBase.Radiators.RadiatiorBaseDataDefinition Type_Radiator_Kitchen = AixLib.DataBase.Radiators.StandardMFD_WSchV1984_OneAppartment.Kitchen()
     "Kitchen"                                                                                                     annotation(Dialog(group = "Radiators", descriptionLabel = true));
-  Fluid.HeatExchangers.Radiators.Radiator radiatorKitchen(RadiatorType = Type_Radiator_Kitchen,
-      m_flow_nominal=0.01,
-    redeclare package Medium = Medium)                                                          annotation(Placement(transformation(extent = {{-89, -83}, {-106, -66}})));
-  Fluid.HeatExchangers.Radiators.Radiator radiator_bath(RadiatorType = Type_Radiator_Bath,
-      m_flow_nominal=0.01,
-    redeclare package Medium = Medium)                                                     annotation(Placement(transformation(extent = {{83, -48}, {100, -31}})));
-  Fluid.Actuators.Valves.ThermostaticValve valve_kitchen(Kvs = 0.41, Kv_setT = 0.262,
+  Fluid.HeatExchangers.Radiators.Radiator radiatorKi(
+    RadiatorType=Type_Radiator_Kitchen,
+    m_flow_nominal=0.01,
+    redeclare package Medium = Medium)
+    annotation (Placement(transformation(extent={{-89,-83},{-106,-66}})));
+  Fluid.HeatExchangers.Radiators.Radiator radiatorBa(
+    RadiatorType=Type_Radiator_Bath,
+    m_flow_nominal=0.01,
+    redeclare package Medium = Medium)
+    annotation (Placement(transformation(extent={{83,-48},{100,-31}})));
+  Fluid.Actuators.Valves.ThermostaticValve valveKi(
+    Kvs=0.41,
+    Kv_setT=0.262,
     m_flow_small=0.0001,
     redeclare package Medium = Medium,
-    dp(start=1000))                                                                                     annotation(Placement(transformation(extent = {{-67, -82.5}, {-82, -66.5}})));
-  Fluid.HeatExchangers.Radiators.Radiator radiator_livingroom(RadiatorType = Type_Radiator_Livingroom,
-      m_flow_nominal=0.01,
-    redeclare package Medium = Medium)                                                                 annotation(Placement(transformation(extent = {{-95, -5}, {-113, 13}})));
-  Fluid.HeatExchangers.Radiators.Radiator radiator_bedroom(RadiatorType = Type_Radiator_Bedroom,
-      m_flow_nominal=0.01,
-    redeclare package Medium = Medium)                                                           annotation(Placement(transformation(extent = {{78, 72}, {94, 88}})));
-  Fluid.HeatExchangers.Radiators.Radiator radiatorCorridor(RadiatorType = Type_Radiator_Children,
-      m_flow_nominal=0.01,
-    redeclare package Medium = Medium)                                                            annotation(Placement(transformation(extent = {{86, 33}, {101, 48}})));
-  Fluid.Actuators.Valves.ThermostaticValve valve_bath(Kvs = 0.24, Kv_setT = 0.162,
+    dp(start=1000))
+    annotation (Placement(transformation(extent={{-67,-82.5},{-82,-66.5}})));
+  Fluid.HeatExchangers.Radiators.Radiator radiatorLi(
+    RadiatorType=Type_Radiator_Livingroom,
+    m_flow_nominal=0.01,
+    redeclare package Medium = Medium)
+    annotation (Placement(transformation(extent={{-95,-5},{-113,13}})));
+  Fluid.HeatExchangers.Radiators.Radiator radiatorBr(
+    RadiatorType=Type_Radiator_Bedroom,
+    m_flow_nominal=0.01,
+    redeclare package Medium = Medium)
+    annotation (Placement(transformation(extent={{78,72},{94,88}})));
+  Fluid.HeatExchangers.Radiators.Radiator radiatorCh(
+    RadiatorType=Type_Radiator_Children,
+    m_flow_nominal=0.01,
+    redeclare package Medium = Medium)
+    annotation (Placement(transformation(extent={{86,33},{101,48}})));
+  Fluid.Actuators.Valves.ThermostaticValve valveBa(
+    Kvs=0.24,
+    Kv_setT=0.162,
     m_flow_small=0.0001,
     redeclare package Medium = Medium,
-    dp(start=1000))                                                                                  annotation(Placement(transformation(extent = {{38, -47}, {50, -31}})));
-  Fluid.Actuators.Valves.ThermostaticValve valve_livingroom(Kvs = 1.43, Kv_setT = 0.4,
+    dp(start=1000))
+    annotation (Placement(transformation(extent={{38,-47},{50,-31}})));
+  Fluid.Actuators.Valves.ThermostaticValve valveLi(
+    Kvs=1.43,
+    Kv_setT=0.4,
     m_flow_small=0.0001,
     redeclare package Medium = Medium,
-    dp(start=1000))                                                                                      annotation(Placement(transformation(extent = {{-67, -4}, {-79, 12}})));
-  Fluid.Actuators.Valves.ThermostaticValve valve_children(Kvs = 0.16, Kv_setT = 0.088,
+    dp(start=1000))
+    annotation (Placement(transformation(extent={{-67,-4},{-79,12}})));
+  Fluid.Actuators.Valves.ThermostaticValve valveCh(
+    Kvs=0.16,
+    Kv_setT=0.088,
     m_flow_small=0.0001,
     redeclare package Medium = Medium,
-    dp(start=1000))                                                                                      annotation(Placement(transformation(extent = {{64, 32}, {76, 48}})));
-  Fluid.Actuators.Valves.ThermostaticValve valve_bedroom(Kvs = 0.24, Kv_setT = 0.182,
+    dp(start=1000))
+    annotation (Placement(transformation(extent={{64,32},{76,48}})));
+  Fluid.Actuators.Valves.ThermostaticValve valveBe(
+    Kvs=0.24,
+    Kv_setT=0.182,
     m_flow_small=0.0001,
     redeclare package Medium = Medium,
-    dp(start=1000))                                                                                     annotation(Placement(transformation(extent = {{49, 74}, {60, 87}})));
+    dp(start=1000))
+    annotation (Placement(transformation(extent={{49,74},{60,87}})));
   Fluid.FixedResistances.StaticPipe thStF(D = Diam_Main, l = Length_thSt,
     m_flow_small=0.0001,
     redeclare package Medium = Medium) "through the storage room, flow stream"                        annotation(Placement(transformation(extent = {{57, -85}, {40, -74}})));
@@ -130,88 +155,239 @@ model Radiators
   Fluid.FixedResistances.StaticPipe toLiR(D = Diam_Main, l = Length_toLi,
     m_flow_small=0.0001,
     redeclare package Medium = Medium) "to livingroom, return stream"                        annotation(Placement(transformation(extent = {{6.5, -5}, {-6.5, 5}}, rotation = 180, origin = {-88.5, -16.5})));
-  HVAC.Interfaces.RadPort Rad_Livingroom annotation(Placement(transformation(extent = {{-148, 38}, {-132, 55}})));
-  Modelica.Thermal.HeatTransfer.Interfaces.HeatPort_a Con_Livingroom annotation(Placement(transformation(extent = {{-146, 25}, {-133, 38}})));
-  HVAC.Interfaces.RadPort Rad_kitchen annotation(Placement(transformation(extent = {{-146, -50}, {-129, -34}})));
-  Modelica.Thermal.HeatTransfer.Interfaces.HeatPort_a Con_kitchen annotation(Placement(transformation(extent = {{-145, -66}, {-131, -51}})));
-  HVAC.Interfaces.RadPort Rad_bedroom annotation(Placement(transformation(extent = {{128, 88}, {146, 106}})));
-  Modelica.Thermal.HeatTransfer.Interfaces.HeatPort_a Con_bedroom annotation(Placement(transformation(extent = {{130, 64}, {146, 82}})));
-  HVAC.Interfaces.RadPort Rad_children annotation(Placement(transformation(extent = {{130, 39}, {150, 59}})));
-  Modelica.Thermal.HeatTransfer.Interfaces.HeatPort_a Con_children annotation(Placement(transformation(extent = {{131, 17}, {146, 34}})));
-  HVAC.Interfaces.RadPort Rad_bath annotation(Placement(transformation(extent = {{128, -38}, {148, -18}})));
-  Modelica.Thermal.HeatTransfer.Interfaces.HeatPort_a Con_bath annotation(Placement(transformation(extent = {{129, -59}, {148, -41}})));
+  HVAC.Interfaces.RadPort radLi
+    annotation (Placement(transformation(extent={{-148,38},{-132,55}})));
+  Modelica.Thermal.HeatTransfer.Interfaces.HeatPort_a convLi
+    annotation (Placement(transformation(extent={{-146,25},{-133,38}})));
+  HVAC.Interfaces.RadPort radKi
+    annotation (Placement(transformation(extent={{-146,-50},{-129,-34}})));
+  Modelica.Thermal.HeatTransfer.Interfaces.HeatPort_a convKi
+    annotation (Placement(transformation(extent={{-145,-66},{-131,-51}})));
+  HVAC.Interfaces.RadPort radBe
+    annotation (Placement(transformation(extent={{128,88},{146,106}})));
+  Modelica.Thermal.HeatTransfer.Interfaces.HeatPort_a convBe
+    annotation (Placement(transformation(extent={{130,64},{146,82}})));
+  HVAC.Interfaces.RadPort radCh
+    annotation (Placement(transformation(extent={{130,39},{150,59}})));
+  Modelica.Thermal.HeatTransfer.Interfaces.HeatPort_a convCh
+    annotation (Placement(transformation(extent={{131,17},{146,34}})));
+  HVAC.Interfaces.RadPort radBa
+    annotation (Placement(transformation(extent={{128,-38},{148,-18}})));
+  Modelica.Thermal.HeatTransfer.Interfaces.HeatPort_a convBa
+    annotation (Placement(transformation(extent={{129,-59},{148,-41}})));
   Modelica.Blocks.Interfaces.RealInput TSet[5] annotation(Placement(transformation(extent = {{-123, 78}, {-95, 108}}), iconTransformation(extent = {{-10.5, -12}, {10.5, 12}}, rotation = 270, origin = {-105.5, 96})));
-  Fluid.FixedResistances.HydraulicResistance HydRes_InFl(zeta = zeta_bend, D = Diam_Main,
+  Fluid.FixedResistances.HydraulicResistance hydResInflow(
+    zeta=zeta_bend,
+    D=Diam_Main,
     m_flow_small=0.0001,
-    redeclare package Medium = Medium) "hydraulic resistance in floor"                                                       annotation(Placement(transformation(extent = {{24, -84}, {10, -75}})));
-  Fluid.FixedResistances.HydraulicResistance HydRes_RadKi(zeta = 3 * zeta_bend, D = Diam_Sec,
+    redeclare package Medium = Medium) "hydraulic resistance in floor"
+    annotation (Placement(transformation(extent={{24,-84},{10,-75}})));
+  Fluid.FixedResistances.HydraulicResistance hydResRadKi(
+    zeta=3*zeta_bend,
+    D=Diam_Sec,
     m_flow_small=0.0001,
-    redeclare package Medium = Medium)                                                        annotation(Placement(transformation(extent = {{-113, -100.5}, {-99, -91.5}})));
-  Fluid.FixedResistances.HydraulicResistance HydRes_BendRight(zeta = zeta_bend, D = Diam_Main,
+    redeclare package Medium = Medium)
+    annotation (Placement(transformation(extent={{-113,-100.5},{-99,-91.5}})));
+  Fluid.FixedResistances.HydraulicResistance hydResBendRight(
+    zeta=zeta_bend,
+    D=Diam_Main,
     m_flow_small=0.0001,
-    redeclare package Medium = Medium) "hydraulic resistance bend right"                                                            annotation(Placement(transformation(extent = {{-3.25, -2.25}, {3.25, 2.25}}, rotation = 90, origin = {-3.75, -75.75})));
-  Fluid.FixedResistances.HydraulicResistance HydRes_RadWC(zeta = 2 * zeta_bend, D = Diam_Sec,
+    redeclare package Medium = Medium) "hydraulic resistance bend right"
+    annotation (Placement(transformation(
+        extent={{-3.25,-2.25},{3.25,2.25}},
+        rotation=90,
+        origin={-3.75,-75.75})));
+  Fluid.FixedResistances.HydraulicResistance hydResRadBa(
+    zeta=2*zeta_bend,
+    D=Diam_Sec,
     m_flow_small=0.0001,
-    redeclare package Medium = Medium)                                                        annotation(Placement(transformation(extent = {{67, -53}, {57, -44}})));
-  Fluid.FixedResistances.HydraulicResistance HydRes_RadLi(zeta = 3 * zeta_bend, D = Diam_Sec,
+    redeclare package Medium = Medium)
+    annotation (Placement(transformation(extent={{67,-53},{57,-44}})));
+  Fluid.FixedResistances.HydraulicResistance hydResRadLi(
+    zeta=3*zeta_bend,
+    D=Diam_Sec,
     m_flow_small=0.0001,
-    redeclare package Medium = Medium)                                                        annotation(Placement(transformation(extent = {{-116, -21}, {-102, -12}})));
-  Fluid.FixedResistances.HydraulicResistance HydRes_RadChildren(zeta = 2 * zeta_bend, D = Diam_Sec,
+    redeclare package Medium = Medium)
+    annotation (Placement(transformation(extent={{-116,-21},{-102,-12}})));
+  Fluid.FixedResistances.HydraulicResistance hydResRadCh(
+    zeta=2*zeta_bend,
+    D=Diam_Sec,
     m_flow_small=0.0001,
-    redeclare package Medium = Medium)                                                              annotation(Placement(transformation(extent = {{84, 22.5}, {74, 31.5}})));
-  Fluid.FixedResistances.HydraulicResistance HydRes_RadBedroom(zeta = 3 * zeta_bend, D = Diam_Sec,
+    redeclare package Medium = Medium)
+    annotation (Placement(transformation(extent={{84,22.5},{74,31.5}})));
+  Fluid.FixedResistances.HydraulicResistance hydResRadBe(
+    zeta=3*zeta_bend,
+    D=Diam_Sec,
     m_flow_small=0.0001,
-    redeclare package Medium = Medium)                                                             annotation(Placement(transformation(extent = {{74, 61.5}, {60, 70.5}})));
-  Modelica.Thermal.HeatTransfer.Sensors.TemperatureSensor tempSensor_livingroom annotation(Placement(transformation(extent = {{-108, 30}, {-96, 42}})));
-  Modelica.Thermal.HeatTransfer.Sensors.TemperatureSensor tempSensor_bedroom annotation(Placement(transformation(extent = {{75, 92}, {63, 104}})));
-  Modelica.Thermal.HeatTransfer.Sensors.TemperatureSensor tempSensor_children annotation(Placement(transformation(extent = {{88, 49}, {76, 61}})));
-  Modelica.Thermal.HeatTransfer.Sensors.TemperatureSensor tempSensor_bath annotation(Placement(transformation(extent = {{66, -21}, {54, -9}})));
-  Modelica.Thermal.HeatTransfer.Sensors.TemperatureSensor tempSensor_bath1 annotation(Placement(transformation(extent = {{-91, -57}, {-79, -45}})));
+    redeclare package Medium = Medium)
+    annotation (Placement(transformation(extent={{74,61.5},{60,70.5}})));
+  Modelica.Thermal.HeatTransfer.Sensors.TemperatureSensor tempSensorLi
+    annotation (Placement(transformation(extent={{-108,30},{-96,42}})));
+  Modelica.Thermal.HeatTransfer.Sensors.TemperatureSensor tempSensorBe
+    annotation (Placement(transformation(extent={{75,92},{63,104}})));
+  Modelica.Thermal.HeatTransfer.Sensors.TemperatureSensor tempSensorCh
+    annotation (Placement(transformation(extent={{88,49},{76,61}})));
+  Modelica.Thermal.HeatTransfer.Sensors.TemperatureSensor tempSensorBa
+    annotation (Placement(transformation(extent={{66,-21},{54,-9}})));
+  Modelica.Thermal.HeatTransfer.Sensors.TemperatureSensor tempSensorKi
+    annotation (Placement(transformation(extent={{-91,-57},{-79,-45}})));
 equation
-  connect(radiator_livingroom.port_a, valve_livingroom.port_b) annotation(Line(points={{-95,4},
-          {-79,4}},                                                                                              color = {255, 0, 0}, smooth = Smooth.None, thickness = 0.5));
-  connect(valve_bath.port_b, radiator_bath.port_a) annotation(Line(points={{50,-39},
-          {83,-39},{83,-39.5}},                                                                                        color = {255, 0, 0}, smooth = Smooth.None, thickness = 0.5));
-  connect(valve_children.port_b, radiatorCorridor.port_a) annotation(Line(points={{76,40},
-          {86,40},{86,40.5}},                                                                                            color = {255, 0, 0}, smooth = Smooth.None, thickness = 0.5));
-  connect(valve_bedroom.port_b, radiator_bedroom.port_a) annotation(Line(points={{60,80.5},
-          {78,80.5},{78,80}},                                                                                               color = {255, 0, 0}, smooth = Smooth.None, thickness = 0.5));
+  connect(radiatorLi.port_a, valveLi.port_b) annotation (Line(
+      points={{-95,4},{-79,4}},
+      color={255,0,0},
+      smooth=Smooth.None,
+      thickness=0.5));
+  connect(valveBa.port_b, radiatorBa.port_a) annotation (Line(
+      points={{50,-39},{83,-39},{83,-39.5}},
+      color={255,0,0},
+      smooth=Smooth.None,
+      thickness=0.5));
+  connect(valveCh.port_b, radiatorCh.port_a) annotation (Line(
+      points={{76,40},{86,40},{86,40.5}},
+      color={255,0,0},
+      smooth=Smooth.None,
+      thickness=0.5));
+  connect(valveBe.port_b, radiatorBr.port_a) annotation (Line(
+      points={{60,80.5},{78,80.5},{78,80}},
+      color={255,0,0},
+      smooth=Smooth.None,
+      thickness=0.5));
   connect(thStR.port_b, RETURN) annotation(Line(points = {{58, -96}, {76, -96}, {76, -104}}, color = {0, 0, 255}, smooth = Smooth.None, thickness = 0.5));
   connect(thStF.port_a, FLOW) annotation(Line(points = {{57, -79.5}, {60, -80}, {62, -80}, {62, -95}, {102, -95}, {102, -104}}, color = {255, 0, 0}, smooth = Smooth.None, thickness = 0.5));
-  connect(toBathF.port_b, valve_bath.port_a) annotation(Line(points = {{27, -38.5}, {39, -38.5}, {39, -39}, {38, -39}}, color = {255, 0, 0}, smooth = Smooth.None, thickness = 0.5));
-  connect(toChildrenF.port_b, valve_children.port_a) annotation(Line(points = {{54, 40.5}, {56, 40}, {64, 40}}, color = {255, 0, 0}, smooth = Smooth.None, thickness = 0.5));
-  connect(toBedroomF.port_b, valve_bedroom.port_a) annotation(Line(points = {{30, 80.5}, {49, 80.5}}, color = {255, 0, 0}, smooth = Smooth.None, thickness = 0.5));
-  connect(toLiF.port_b, valve_livingroom.port_a) annotation(Line(points = {{-53.5, 3}, {-53.5, 4}, {-67, 4}}, color = {255, 0, 0}, thickness = 0.5, smooth = Smooth.None));
-  connect(valve_kitchen.port_a, toKiF.port_b) annotation(Line(points = {{-67, -74.5}, {-57, -74.5}}, color = {255, 0, 0}, smooth = Smooth.None, thickness = 0.5));
-  connect(radiatorKitchen.port_a, valve_kitchen.port_b) annotation(Line(points={{-89,
-          -74.5},{-82,-74.5}},                                                                                    color = {255, 0, 0}, smooth = Smooth.None, thickness = 0.5));
-  connect(HydRes_InFl.port_a, thStF.port_b) annotation(Line(points = {{24, -79.5}, {40, -79.5}}, color = {255, 0, 0}, smooth = Smooth.None, thickness = 0.5));
-  connect(radiatorKitchen.port_b, HydRes_RadKi.port_a) annotation(Line(points={{-106,
-          -74.5},{-118,-74.5},{-118,-75},{-130,-75},{-130,-96},{-113,-96}},                                                                                            color = {0, 128, 255}, smooth = Smooth.None, thickness = 0.5));
-  connect(HydRes_RadKi.port_b, toKiR.port_a) annotation(Line(points = {{-99, -96}, {-72, -96}}, color = {0, 128, 255}, smooth = Smooth.None, thickness = 0.5));
-  connect(toBathR.port_a, HydRes_RadWC.port_b) annotation(Line(points = {{27, -49.5}, {42, -49.5}, {42, -48.5}, {57, -48.5}}, color = {0, 128, 255}, smooth = Smooth.None, thickness = 0.5));
-  connect(HydRes_RadWC.port_a, radiator_bath.port_b) annotation(Line(points={{67,
-          -48.5},{127,-48.5},{127,-39.5},{100,-39.5}},                                                                                   color = {0, 128, 255}, smooth = Smooth.None, thickness = 0.5));
-  connect(HydRes_RadLi.port_b, toLiR.port_a) annotation(Line(points = {{-102, -16.5}, {-95, -16.5}}, color = {0, 128, 255}, smooth = Smooth.None, thickness = 0.5));
-  connect(HydRes_RadLi.port_a, radiator_livingroom.port_b) annotation(Line(points={{-116,
-          -16.5},{-129,-16.5},{-129,4},{-113,4}},                                                                                            color = {0, 128, 255}, smooth = Smooth.None, thickness = 0.5));
-  connect(toChildrenR.port_a, HydRes_RadChildren.port_b) annotation(Line(points = {{55, 27}, {74, 27}}, color = {0, 128, 255}, smooth = Smooth.None, thickness = 0.5));
-  connect(HydRes_RadChildren.port_a, radiatorCorridor.port_b) annotation(Line(points={{84,27},
-          {126,27},{126,40.5},{101,40.5}},                                                                                                color = {0, 128, 255}, smooth = Smooth.None, thickness = 0.5));
-  connect(toBedroomR.port_a, HydRes_RadBedroom.port_b) annotation(Line(points = {{27, 66}, {60, 66}}, color = {0, 128, 255}, smooth = Smooth.None, thickness = 0.5));
-  connect(HydRes_RadBedroom.port_a, radiator_bedroom.port_b) annotation(Line(points={{74,66},
-          {126,66},{126,80},{94,80}},                                                                                                color = {0, 128, 255}, smooth = Smooth.None, thickness = 0.5));
-  connect(HydRes_BendRight.port_b, thBathF.port_a) annotation(Line(points = {{-3.75, -72.5}, {-3.75, -70}, {-4.5, -70}}, color = {0, 127, 255}, smooth = Smooth.None));
-  connect(radiatorKitchen.radPort, Rad_kitchen) annotation(Line(points = {{-100.9, -67.87}, {-100.9, -42}, {-137.5, -42}}, color = {0, 0, 0}, smooth = Smooth.None));
-  connect(radiatorKitchen.convPort, Con_kitchen) annotation(Line(points = {{-93.93, -68.04}, {-93.93, -58.5}, {-138, -58.5}}, color = {191, 0, 0}, smooth = Smooth.None));
-  connect(radiator_bath.convPort, Con_bath) annotation(Line(points = {{87.93, -33.04}, {88, -33.04}, {88, -33}, {119, -33}, {119, -50}, {138.5, -50}}, color = {191, 0, 0}, smooth = Smooth.None));
-  connect(radiator_bath.radPort, Rad_bath) annotation(Line(points = {{94.9, -32.87}, {94.9, -28}, {138, -28}}, color = {0, 0, 0}, smooth = Smooth.None));
-  connect(radiatorCorridor.radPort, Rad_children) annotation(Line(points = {{96.5, 46.35}, {96.5, 49}, {140, 49}}, color = {0, 0, 0}, smooth = Smooth.None));
-  connect(radiatorCorridor.convPort, Con_children) annotation(Line(points = {{90.35, 46.2}, {90, 46.2}, {90, 46}, {113, 46}, {113, 25.5}, {138.5, 25.5}}, color = {191, 0, 0}, smooth = Smooth.None));
-  connect(radiator_bedroom.convPort, Con_bedroom) annotation(Line(points = {{82.64, 86.08}, {82.64, 91}, {119, 91}, {119, 73}, {138, 73}}, color = {191, 0, 0}, smooth = Smooth.None));
-  connect(radiator_bedroom.radPort, Rad_bedroom) annotation(Line(points = {{89.2, 86.24}, {89.2, 97}, {137, 97}}, color = {0, 0, 0}, smooth = Smooth.None));
-  connect(radiator_livingroom.radPort, Rad_Livingroom) annotation(Line(points = {{-107.6, 11.02}, {-107.6, 11}, {-131, 11}, {-131, 46}, {-136, 46}, {-136, 46.5}, {-140, 46.5}}, color = {0, 0, 0}, smooth = Smooth.None));
-  connect(radiator_livingroom.convPort, Con_Livingroom) annotation(Line(points = {{-100.22, 10.84}, {-100.22, 12}, {-100, 12}, {-100, 14}, {-133, 14}, {-133, 32}, {-137, 32}, {-137, 31.5}, {-139.5, 31.5}}, color = {191, 0, 0}, smooth = Smooth.None));
+  connect(toBathF.port_b, valveBa.port_a) annotation (Line(
+      points={{27,-38.5},{39,-38.5},{39,-39},{38,-39}},
+      color={255,0,0},
+      smooth=Smooth.None,
+      thickness=0.5));
+  connect(toChildrenF.port_b, valveCh.port_a) annotation (Line(
+      points={{54,40.5},{56,40},{64,40}},
+      color={255,0,0},
+      smooth=Smooth.None,
+      thickness=0.5));
+  connect(toBedroomF.port_b, valveBe.port_a) annotation (Line(
+      points={{30,80.5},{49,80.5}},
+      color={255,0,0},
+      smooth=Smooth.None,
+      thickness=0.5));
+  connect(toLiF.port_b, valveLi.port_a) annotation (Line(
+      points={{-53.5,3},{-53.5,4},{-67,4}},
+      color={255,0,0},
+      thickness=0.5,
+      smooth=Smooth.None));
+  connect(valveKi.port_a, toKiF.port_b) annotation (Line(
+      points={{-67,-74.5},{-57,-74.5}},
+      color={255,0,0},
+      smooth=Smooth.None,
+      thickness=0.5));
+  connect(radiatorKi.port_a, valveKi.port_b) annotation (Line(
+      points={{-89,-74.5},{-82,-74.5}},
+      color={255,0,0},
+      smooth=Smooth.None,
+      thickness=0.5));
+  connect(hydResInflow.port_a, thStF.port_b) annotation (Line(
+      points={{24,-79.5},{40,-79.5}},
+      color={255,0,0},
+      smooth=Smooth.None,
+      thickness=0.5));
+  connect(radiatorKi.port_b, hydResRadKi.port_a) annotation (Line(
+      points={{-106,-74.5},{-118,-74.5},{-118,-75},{-130,-75},{-130,-96},{-113,
+          -96}},
+      color={0,128,255},
+      smooth=Smooth.None,
+      thickness=0.5));
+  connect(hydResRadKi.port_b, toKiR.port_a) annotation (Line(
+      points={{-99,-96},{-72,-96}},
+      color={0,128,255},
+      smooth=Smooth.None,
+      thickness=0.5));
+  connect(toBathR.port_a, hydResRadBa.port_b) annotation (Line(
+      points={{27,-49.5},{42,-49.5},{42,-48.5},{57,-48.5}},
+      color={0,128,255},
+      smooth=Smooth.None,
+      thickness=0.5));
+  connect(hydResRadBa.port_a, radiatorBa.port_b) annotation (Line(
+      points={{67,-48.5},{127,-48.5},{127,-39.5},{100,-39.5}},
+      color={0,128,255},
+      smooth=Smooth.None,
+      thickness=0.5));
+  connect(hydResRadLi.port_b, toLiR.port_a) annotation (Line(
+      points={{-102,-16.5},{-95,-16.5}},
+      color={0,128,255},
+      smooth=Smooth.None,
+      thickness=0.5));
+  connect(hydResRadLi.port_a, radiatorLi.port_b) annotation (Line(
+      points={{-116,-16.5},{-129,-16.5},{-129,4},{-113,4}},
+      color={0,128,255},
+      smooth=Smooth.None,
+      thickness=0.5));
+  connect(toChildrenR.port_a, hydResRadCh.port_b) annotation (Line(
+      points={{55,27},{74,27}},
+      color={0,128,255},
+      smooth=Smooth.None,
+      thickness=0.5));
+  connect(hydResRadCh.port_a, radiatorCh.port_b) annotation (Line(
+      points={{84,27},{126,27},{126,40.5},{101,40.5}},
+      color={0,128,255},
+      smooth=Smooth.None,
+      thickness=0.5));
+  connect(toBedroomR.port_a, hydResRadBe.port_b) annotation (Line(
+      points={{27,66},{60,66}},
+      color={0,128,255},
+      smooth=Smooth.None,
+      thickness=0.5));
+  connect(hydResRadBe.port_a, radiatorBr.port_b) annotation (Line(
+      points={{74,66},{126,66},{126,80},{94,80}},
+      color={0,128,255},
+      smooth=Smooth.None,
+      thickness=0.5));
+  connect(hydResBendRight.port_b, thBathF.port_a) annotation (Line(
+      points={{-3.75,-72.5},{-3.75,-70},{-4.5,-70}},
+      color={0,127,255},
+      smooth=Smooth.None));
+  connect(radiatorKi.radPort, radKi) annotation (Line(
+      points={{-100.9,-67.87},{-100.9,-42},{-137.5,-42}},
+      color={0,0,0},
+      smooth=Smooth.None));
+  connect(radiatorKi.convPort, convKi) annotation (Line(
+      points={{-93.93,-68.04},{-93.93,-58.5},{-138,-58.5}},
+      color={191,0,0},
+      smooth=Smooth.None));
+  connect(radiatorBa.convPort, convBa) annotation (Line(
+      points={{87.93,-33.04},{88,-33.04},{88,-33},{119,-33},{119,-50},{138.5,-50}},
+
+      color={191,0,0},
+      smooth=Smooth.None));
+  connect(radiatorBa.radPort, radBa) annotation (Line(
+      points={{94.9,-32.87},{94.9,-28},{138,-28}},
+      color={0,0,0},
+      smooth=Smooth.None));
+  connect(radiatorCh.radPort, radCh) annotation (Line(
+      points={{96.5,46.35},{96.5,49},{140,49}},
+      color={0,0,0},
+      smooth=Smooth.None));
+  connect(radiatorCh.convPort, convCh) annotation (Line(
+      points={{90.35,46.2},{90,46.2},{90,46},{113,46},{113,25.5},{138.5,25.5}},
+
+      color={191,0,0},
+      smooth=Smooth.None));
+  connect(radiatorBr.convPort, convBe) annotation (Line(
+      points={{82.64,86.08},{82.64,91},{119,91},{119,73},{138,73}},
+      color={191,0,0},
+      smooth=Smooth.None));
+  connect(radiatorBr.radPort, radBe) annotation (Line(
+      points={{89.2,86.24},{89.2,97},{137,97}},
+      color={0,0,0},
+      smooth=Smooth.None));
+  connect(radiatorLi.radPort, radLi) annotation (Line(
+      points={{-107.6,11.02},{-107.6,11},{-131,11},{-131,46},{-136,46},{-136,
+          46.5},{-140,46.5}},
+      color={0,0,0},
+      smooth=Smooth.None));
+  connect(radiatorLi.convPort, convLi) annotation (Line(
+      points={{-100.22,10.84},{-100.22,12},{-100,12},{-100,14},{-133,14},{-133,
+          32},{-137,32},{-137,31.5},{-139.5,31.5}},
+      color={191,0,0},
+      smooth=Smooth.None));
   connect(toKiR.port_b, thStR.port_a) annotation(Line(points = {{-56, -96}, {40, -96}}, color = {0, 127, 255}, smooth = Smooth.None, thickness = 0.5));
   connect(thBathR.port_b, thStR.port_a) annotation(Line(points = {{-18.25, -71.5}, {-18.25, -96}, {40, -96}}, color = {0, 127, 255}, smooth = Smooth.None, thickness = 0.5));
   connect(thChildren1R.port_b, thBathR.port_a) annotation(Line(points = {{-18, -34}, {-18, -54}, {-18.25, -54}}, color = {0, 127, 255}, smooth = Smooth.None, thickness = 0.5));
@@ -220,48 +396,102 @@ equation
   connect(toBedroomR.port_b, thChildrenR2.port_a) annotation(Line(points = {{14, 66}, {-19, 66}, {-19, 20}}, color = {0, 127, 255}, smooth = Smooth.None, thickness = 0.5));
   connect(toChildrenR.port_b, thChildrenR2.port_a) annotation(Line(points = {{40, 27}, {-19, 27}, {-19, 20}}, color = {0, 127, 255}, smooth = Smooth.None, thickness = 0.5));
   connect(toBathR.port_b, thBathR.port_a) annotation(Line(points = {{10, -49.5}, {-18, -49.5}, {-18, -54}, {-18.25, -54}}, color = {0, 127, 255}, smooth = Smooth.None, thickness = 0.5));
-  connect(HydRes_BendRight.port_a, HydRes_InFl.port_b) annotation(Line(points = {{-3.75, -79}, {-3.75, -79.5}, {10, -79.5}}, color = {0, 127, 255}, smooth = Smooth.None));
+  connect(hydResBendRight.port_a, hydResInflow.port_b) annotation (Line(
+      points={{-3.75,-79},{-3.75,-79.5},{10,-79.5}},
+      color={0,127,255},
+      smooth=Smooth.None));
   connect(thBathF.port_b, toBathF.port_a) annotation(Line(points = {{-4.5, -54}, {-4.5, -38.5}, {10, -38.5}}, color = {255, 0, 0}, smooth = Smooth.None, thickness = 0.5));
-  connect(toKiF.port_a, HydRes_InFl.port_b) annotation(Line(points = {{-41, -74.5}, {-23, -74.5}, {-23, -80}, {10, -80}, {10, -79.5}}, color = {255, 0, 0}, smooth = Smooth.None, thickness = 0.5));
+  connect(toKiF.port_a, hydResInflow.port_b) annotation (Line(
+      points={{-41,-74.5},{-23,-74.5},{-23,-80},{10,-80},{10,-79.5}},
+      color={255,0,0},
+      smooth=Smooth.None,
+      thickness=0.5));
   connect(thBathF.port_b, thChildren1F.port_a) annotation(Line(points = {{-4.5, -54}, {-4.5, -44}, {-5, -44}, {-5, -33}}, color = {255, 0, 0}, smooth = Smooth.None, thickness = 0.5));
   connect(thChildren1F.port_b, thChildrenF2.port_a) annotation(Line(points = {{-5, -20}, {-5, 6}}, color = {0, 127, 255}, smooth = Smooth.None));
   connect(thChildrenF2.port_b, toChildrenF.port_a) annotation(Line(points = {{-5, 20}, {-5, 40.5}, {37, 40.5}}, color = {255, 0, 0}, smooth = Smooth.None, thickness = 0.5));
   connect(thChildrenF2.port_b, toBedroomF.port_a) annotation(Line(points = {{-5, 20}, {-5, 80.5}, {17, 80.5}}, color = {255, 0, 0}, smooth = Smooth.None, thickness = 0.5));
   connect(thChildren1F.port_b, toLiF.port_a) annotation(Line(points = {{-5, -20}, {-5, 3}, {-41.5, 3}}, color = {255, 0, 0}, smooth = Smooth.None, thickness = 0.5));
-  connect(valve_bedroom.T_setRoom, TSet[2]) annotation(Line(points = {{57.58, 86.87}, {57.58, 87}, {-109, 87}}, color = {0, 0, 127}, smooth = Smooth.None));
-  connect(valve_children.T_setRoom, TSet[3]) annotation(Line(points = {{73.36, 47.84}, {73.36, 57}, {-77, 57}, {-77, 92}, {-109, 92}, {-109, 93}}, color = {0, 0, 127}, smooth = Smooth.None));
-  connect(valve_bath.T_setRoom, TSet[4]) annotation(Line(points = {{47.36, -31.16}, {47.36, -7}, {18, -7}, {18, 29}, {-76, 29}, {-76, 99}, {-109, 99}}, color = {0, 0, 127}, smooth = Smooth.None));
-  connect(valve_kitchen.T_setRoom, TSet[5]) annotation(Line(points = {{-78.7, -66.66}, {-78.7, -62}, {-76, -62}, {-76, 105}, {-109, 105}}, color = {0, 0, 127}, smooth = Smooth.None));
-  connect(valve_livingroom.T_setRoom, TSet[1]) annotation(Line(points = {{-76.36, 11.84}, {-76.36, 52}, {-76, 52}, {-76, 92}, {-109, 92}, {-109, 81}}, color = {0, 0, 127}, smooth = Smooth.None));
-  connect(Con_Livingroom, tempSensor_livingroom.port) annotation(Line(points = {{-139.5, 31.5}, {-120, 31.5}, {-120, 36}, {-108, 36}}, color = {191, 0, 0}, smooth = Smooth.None));
-  connect(tempSensor_livingroom.T, valve_livingroom.T_room) annotation(Line(points = {{-96, 36}, {-69.16, 36}, {-69.16, 11.84}}, color = {0, 0, 127}, smooth = Smooth.None));
-  connect(valve_bedroom.T_room, tempSensor_bedroom.T) annotation(Line(points = {{50.98, 86.87}, {50.98, 98}, {63, 98}}, color = {0, 0, 127}, smooth = Smooth.None));
-  connect(tempSensor_bedroom.port, Con_bedroom) annotation(Line(points = {{75, 98}, {89, 98}, {89, 97}, {141, 97}, {141, 73}, {138, 73}}, color = {191, 0, 0}, smooth = Smooth.None));
-  connect(valve_children.T_room, tempSensor_children.T) annotation(Line(points = {{66.16, 47.84}, {66.16, 55}, {76, 55}}, color = {0, 0, 127}, smooth = Smooth.None));
-  connect(tempSensor_children.port, Con_children) annotation(Line(points = {{88, 55}, {138, 55}, {138, 53}, {138.5, 53}, {138.5, 25.5}}, color = {191, 0, 0}, smooth = Smooth.None));
-  connect(valve_bath.T_room, tempSensor_bath.T) annotation(Line(points = {{40.16, -31.16}, {40.16, -15}, {54, -15}}, color = {0, 0, 127}, smooth = Smooth.None));
-  connect(tempSensor_bath.port, Con_bath) annotation(Line(points = {{66, -15}, {97, -15}, {97, -21}, {138.5, -21}, {138.5, -50}}, color = {191, 0, 0}, smooth = Smooth.None));
-  connect(tempSensor_bath1.port, Con_kitchen) annotation(Line(points = {{-91, -51}, {-107, -51}, {-107, -50}, {-138, -50}, {-138, -58.5}}, color = {191, 0, 0}, smooth = Smooth.None));
-  connect(tempSensor_bath1.T, valve_kitchen.T_room) annotation(Line(points = {{-79, -51}, {-69.7, -51}, {-69.7, -66.66}}, color = {0, 0, 127}, smooth = Smooth.None));
+  connect(valveBe.T_setRoom, TSet[2]) annotation (Line(
+      points={{57.58,86.87},{57.58,87},{-109,87}},
+      color={0,0,127},
+      smooth=Smooth.None));
+  connect(valveCh.T_setRoom, TSet[3]) annotation (Line(
+      points={{73.36,47.84},{73.36,57},{-77,57},{-77,92},{-109,92},{-109,93}},
+      color={0,0,127},
+      smooth=Smooth.None));
+  connect(valveBa.T_setRoom, TSet[4]) annotation (Line(
+      points={{47.36,-31.16},{47.36,-7},{18,-7},{18,29},{-76,29},{-76,99},{-109,
+          99}},
+      color={0,0,127},
+      smooth=Smooth.None));
+  connect(valveKi.T_setRoom, TSet[5]) annotation (Line(
+      points={{-78.7,-66.66},{-78.7,-62},{-76,-62},{-76,105},{-109,105}},
+      color={0,0,127},
+      smooth=Smooth.None));
+  connect(valveLi.T_setRoom, TSet[1]) annotation (Line(
+      points={{-76.36,11.84},{-76.36,52},{-76,52},{-76,92},{-109,92},{-109,81}},
+
+      color={0,0,127},
+      smooth=Smooth.None));
+  connect(convLi, tempSensorLi.port) annotation (Line(
+      points={{-139.5,31.5},{-120,31.5},{-120,36},{-108,36}},
+      color={191,0,0},
+      smooth=Smooth.None));
+  connect(tempSensorLi.T, valveLi.T_room) annotation (Line(
+      points={{-96,36},{-69.16,36},{-69.16,11.84}},
+      color={0,0,127},
+      smooth=Smooth.None));
+  connect(valveBe.T_room, tempSensorBe.T) annotation (Line(
+      points={{50.98,86.87},{50.98,98},{63,98}},
+      color={0,0,127},
+      smooth=Smooth.None));
+  connect(tempSensorBe.port, convBe) annotation (Line(
+      points={{75,98},{89,98},{89,97},{141,97},{141,73},{138,73}},
+      color={191,0,0},
+      smooth=Smooth.None));
+  connect(valveCh.T_room, tempSensorCh.T) annotation (Line(
+      points={{66.16,47.84},{66.16,55},{76,55}},
+      color={0,0,127},
+      smooth=Smooth.None));
+  connect(tempSensorCh.port, convCh) annotation (Line(
+      points={{88,55},{138,55},{138,53},{138.5,53},{138.5,25.5}},
+      color={191,0,0},
+      smooth=Smooth.None));
+  connect(valveBa.T_room, tempSensorBa.T) annotation (Line(
+      points={{40.16,-31.16},{40.16,-15},{54,-15}},
+      color={0,0,127},
+      smooth=Smooth.None));
+  connect(tempSensorBa.port, convBa) annotation (Line(
+      points={{66,-15},{97,-15},{97,-21},{138.5,-21},{138.5,-50}},
+      color={191,0,0},
+      smooth=Smooth.None));
+  connect(tempSensorKi.port, convKi) annotation (Line(
+      points={{-91,-51},{-107,-51},{-107,-50},{-138,-50},{-138,-58.5}},
+      color={191,0,0},
+      smooth=Smooth.None));
+  connect(tempSensorKi.T, valveKi.T_room) annotation (Line(
+      points={{-79,-51},{-69.7,-51},{-69.7,-66.66}},
+      color={0,0,127},
+      smooth=Smooth.None));
   annotation(Diagram(coordinateSystem(preserveAspectRatio=false,   extent={{-150,
-            -100},{150,110}},                                                                           grid = {1, 1}), graphics={  Rectangle(extent=  {{1, 100}, {126, 63}}, pattern=  LinePattern.None, lineColor=  {0, 0, 0}, fillColor=  {215, 215, 215},
-            fillPattern=                                                                                                    FillPattern.Solid), Rectangle(extent=  {{4, 58}, {127, 15}}, pattern=  LinePattern.None, lineColor=  {0, 0, 0}, fillColor=  {215, 215, 215},
-            fillPattern=                                                                                                    FillPattern.Solid), Rectangle(extent=  {{4, -14}, {127, -67}}, pattern=  LinePattern.None, lineColor=  {0, 0, 0}, fillColor=  {215, 215, 215},
-            fillPattern=                                                                                                    FillPattern.Solid), Rectangle(extent=  {{-129, 29}, {-22, -25}}, pattern=  LinePattern.None, lineColor=  {0, 0, 0}, fillColor=  {215, 215, 215},
-            fillPattern=                                                                                                    FillPattern.Solid), Rectangle(extent=  {{-130, -49}, {-23, -103}}, pattern=  LinePattern.None, lineColor=  {0, 0, 0}, fillColor=  {215, 215, 215},
-            fillPattern=                                                                                                    FillPattern.Solid), Text(extent=  {{-120, -81}, {-69, -96}}, lineColor=  {0, 0, 0}, fillColor=  {0, 0, 0},
-            fillPattern=                                                                                                    FillPattern.Solid, textString=  "Kitchen"), Text(extent=  {{-156.5, 29}, {-49.5, 16}}, lineColor=  {0, 0, 0}, fillColor=  {0, 0, 0},
-            fillPattern=                                                                                                    FillPattern.Solid, textString=  "Livingroom"), Text(extent=  {{31, -15}, {138, -28}}, lineColor=  {0, 0, 0}, fillColor=  {0, 0, 0},
-            fillPattern=                                                                                                    FillPattern.Solid, textString=  "Bath"), Text(extent=  {{-27, 56}, {80, 43}}, lineColor=  {0, 0, 0}, fillColor=  {0, 0, 0},
-            fillPattern=                                                                                                    FillPattern.Solid, textString=  "Children"), Text(extent=  {{-34, 100}, {73, 87}}, lineColor=  {0, 0, 0}, fillColor=  {0, 0, 0},
-            fillPattern=                                                                                                    FillPattern.Solid, textString=  "Bedroom"), Text(extent=  {{-70, 103}, {-17, 71}}, lineColor=  {0, 0, 0}, textString=  "1 - Livingroom
+            -100},{150,110}},                                                                           grid = {1, 1}), graphics={  Rectangle(extent = {{1, 100}, {126, 63}}, pattern = LinePattern.None, lineColor = {0, 0, 0}, fillColor = {215, 215, 215},
+            fillPattern =                                                                                                   FillPattern.Solid), Rectangle(extent = {{4, 58}, {127, 15}}, pattern = LinePattern.None, lineColor = {0, 0, 0}, fillColor = {215, 215, 215},
+            fillPattern =                                                                                                   FillPattern.Solid), Rectangle(extent = {{4, -14}, {127, -67}}, pattern = LinePattern.None, lineColor = {0, 0, 0}, fillColor = {215, 215, 215},
+            fillPattern =                                                                                                   FillPattern.Solid), Rectangle(extent = {{-129, 29}, {-22, -25}}, pattern = LinePattern.None, lineColor = {0, 0, 0}, fillColor = {215, 215, 215},
+            fillPattern =                                                                                                   FillPattern.Solid), Rectangle(extent = {{-130, -49}, {-23, -103}}, pattern = LinePattern.None, lineColor = {0, 0, 0}, fillColor = {215, 215, 215},
+            fillPattern =                                                                                                   FillPattern.Solid), Text(extent = {{-120, -81}, {-69, -96}}, lineColor = {0, 0, 0}, fillColor = {0, 0, 0},
+            fillPattern =                                                                                                   FillPattern.Solid, textString = "Kitchen"), Text(extent = {{-156.5, 29}, {-49.5, 16}}, lineColor = {0, 0, 0}, fillColor = {0, 0, 0},
+            fillPattern =                                                                                                   FillPattern.Solid, textString = "Livingroom"), Text(extent = {{31, -15}, {138, -28}}, lineColor = {0, 0, 0}, fillColor = {0, 0, 0},
+            fillPattern =                                                                                                   FillPattern.Solid, textString = "Bath"), Text(extent = {{-27, 56}, {80, 43}}, lineColor = {0, 0, 0}, fillColor = {0, 0, 0},
+            fillPattern =                                                                                                   FillPattern.Solid, textString = "Children"), Text(extent = {{-34, 100}, {73, 87}}, lineColor = {0, 0, 0}, fillColor = {0, 0, 0},
+            fillPattern =                                                                                                   FillPattern.Solid, textString = "Bedroom"), Text(extent = {{-70, 103}, {-17, 71}}, lineColor = {0, 0, 0}, textString = "1 - Livingroom
  2- Bedroom
  3 - Children
  4 - Bath
- 5 - Kitchen")}), Icon(coordinateSystem(preserveAspectRatio = false, extent = {{-150, -100}, {150, 110}}, grid = {1, 1}), graphics={  Rectangle(extent=  {{-119, 92}, {123, -79}}, lineColor=  {255, 0, 0}, fillColor=  {135, 135, 135},
-            fillPattern=                                                                                                    FillPattern.Solid), Line(points=  {{-99, 22}, {104, 22}, {104, -6}}, color=  {255, 0, 0}, smooth=  Smooth.None, thickness=  1), Line(points=  {{-98, 13}, {95, 13}, {95, -6}}, color=  {0, 0, 255}, smooth=  Smooth.None, thickness=  1), Line(points=  {{-21, 13}, {-21, 35}}, color=  {0, 0, 255}, thickness=  1, smooth=  Smooth.None), Line(points=  {{-14, 23}, {-14, 45}}, color=  {255, 0, 0}, thickness=  1, smooth=  Smooth.None), Text(extent=  {{-124, 119}, {-84, 111}}, lineColor=  {0, 0, 0},
-            lineThickness=                                                                                                    0.5, fillColor=  {215, 215, 215},
-            fillPattern=                                                                                                    FillPattern.Solid, textString=  "Set"), Text(extent=  {{-70, 81}, {-17, 49}}, lineColor=  {0, 0, 0}, textString=  "1 - Livingroom
+ 5 - Kitchen")}), Icon(coordinateSystem(preserveAspectRatio = false, extent = {{-150, -100}, {150, 110}}, grid = {1, 1}), graphics={  Rectangle(extent = {{-119, 92}, {123, -79}}, lineColor = {255, 0, 0}, fillColor = {135, 135, 135},
+            fillPattern =                                                                                                   FillPattern.Solid), Line(points = {{-99, 22}, {104, 22}, {104, -6}}, color = {255, 0, 0}, smooth = Smooth.None, thickness = 1), Line(points = {{-98, 13}, {95, 13}, {95, -6}}, color = {0, 0, 255}, smooth = Smooth.None, thickness = 1), Line(points = {{-21, 13}, {-21, 35}}, color = {0, 0, 255}, thickness = 1, smooth = Smooth.None), Line(points = {{-14, 23}, {-14, 45}}, color = {255, 0, 0}, thickness = 1, smooth = Smooth.None), Text(extent = {{-124, 119}, {-84, 111}}, lineColor = {0, 0, 0},
+            lineThickness =                                                                                                   0.5, fillColor = {215, 215, 215},
+            fillPattern =                                                                                                   FillPattern.Solid, textString = "Set"), Text(extent = {{-70, 81}, {-17, 49}}, lineColor = {0, 0, 0}, textString = "1 - Livingroom
  2- Bedroom
  3 - Children
  4 - Bath


### PR DESCRIPTION
In AixLib/Building/HighOrder/House/MFD/EnergySystem/OneAppartment/Radiators.mo (hopefully) rooms are always abbreviated:

- Li: Livingroom
- Ki: Kitchen
- Ch: Child's room
- Ba: Bathroom
- Be: Bedroom

instances are named camelCaseType with first letter small caps.
Because I changed some connectors I changed dependend classes accordingly
Convection is no abbreviated conv, not con.

Tried the VoWo example, it worked, but some naming was changed. Any analysis tools may need to be changed... .