### PR TITLE
Issue345 storage heat transfer modelling style

### DIFF
--- a/AixLib/Fluid/Storage/BaseClasses/HeatTransferLambdaEff.mo
+++ b/AixLib/Fluid/Storage/BaseClasses/HeatTransferLambdaEff.mo
@@ -8,7 +8,7 @@ protected
   parameter Real kappa=0.41 "Karman constant";
   parameter Modelica.SIunits.Length height=data.hTank/n
     "Height of fluid layers";
-  Real beta=350e-6 "Thermal expansion coefficient in 1/K";
+  parameter Real beta=350e-6 "Thermal expansion coefficient in 1/K";
   parameter Modelica.SIunits.Area A=Modelica.Constants.pi/4*data.dTank^2
     "Area of heat transfer between layers";
    parameter Modelica.SIunits.Density rho=1000

--- a/AixLib/Fluid/Storage/BaseClasses/HeatTransferLambdaEffSmooth.mo
+++ b/AixLib/Fluid/Storage/BaseClasses/HeatTransferLambdaEffSmooth.mo
@@ -8,7 +8,7 @@ protected
   parameter Real kappa=0.41 "Karman constant";
   parameter Modelica.SIunits.Length height=data.hTank/n
     "Height of fluid layers";
-  Real beta=350e-6 "Thermal expansion coefficient in 1/K";
+  parameter Real beta=350e-6 "Thermal expansion coefficient in 1/K";
   parameter Modelica.SIunits.Area A=Modelica.Constants.pi/4*data.dTank^2
     "Area of heat transfer between layers";
    parameter Modelica.SIunits.Density rho=1000

--- a/AixLib/Fluid/Storage/BaseClasses/HeatTransferLambdaEffTanh.mo
+++ b/AixLib/Fluid/Storage/BaseClasses/HeatTransferLambdaEffTanh.mo
@@ -10,7 +10,7 @@ protected
   parameter Real kappa=0.41 "Karman constant";
   parameter Modelica.SIunits.Length height=data.hTank/n
     "Height of fluid layers";
-  Real beta=350e-6 "Thermal expansion coefficient in 1/K";
+  parameter Real beta=350e-6 "Thermal expansion coefficient in 1/K";
   parameter Modelica.SIunits.Area A=Modelica.Constants.pi/4*data.dTank^2
     "Area of heat transfer between layers";
    parameter Modelica.SIunits.Density rho=1000

--- a/AixLib/Fluid/Storage/BaseClasses/HeatingCoil.mo
+++ b/AixLib/Fluid/Storage/BaseClasses/HeatingCoil.mo
@@ -9,8 +9,8 @@ model HeatingCoil "Heating coil for heat storage model"
  parameter Modelica.SIunits.CoefficientOfHeatTransfer alphaHC=20
     "Model assumptions Coefficient of Heat Transfer HC <-> Heating Water";
 
- outer parameter Modelica.SIunits.Temperature TStart=298.15
-    "Start Temperature of fluid";
+ parameter Modelica.SIunits.Temperature TStart=298.15
+    "Start Temperature of fluid" annotation(Dialog(group = "Initialization"));
 
  parameter AixLib.DataBase.Pipes.PipeBaseDataDefinition pipeHC=
       AixLib.DataBase.Pipes.Copper.Copper_28x1() "Type of Pipe for HC";

--- a/AixLib/Fluid/Storage/BaseClasses/PartialHeatTransferLayers.mo
+++ b/AixLib/Fluid/Storage/BaseClasses/PartialHeatTransferLayers.mo
@@ -1,13 +1,13 @@
 within AixLib.Fluid.Storage.BaseClasses;
 partial model PartialHeatTransferLayers "Partial for storage heat transfer models"
 
-  outer parameter Integer n(min=2)=3 "Number of layers";
+  parameter Integer n(min=2)=3 "Number of layers";
   Modelica.Thermal.HeatTransfer.Interfaces.HeatPort_a[n] therm annotation (
       Placement(transformation(extent={{40,0},{60,20}}, rotation=0)));
-  outer replaceable package Medium =
+  replaceable package Medium =
       Modelica.Media.Interfaces.PartialMedium "Medium model" annotation(choicesAllMatching);
 
-  outer replaceable parameter
+  replaceable parameter
     AixLib.DataBase.Storage.BufferStorageBaseDataDefinition data=
       AixLib.DataBase.Storage.Generic_500l()
       "Storage data record"

--- a/AixLib/Fluid/Storage/BufferStorage.mo
+++ b/AixLib/Fluid/Storage/BufferStorage.mo
@@ -3,7 +3,7 @@ model BufferStorage
   "Buffer Storage Model with support for heating rod and two heating coils"
   import SI = Modelica.SIunits;
 
-  inner replaceable package Medium =
+  replaceable package Medium =
       Modelica.Media.Interfaces.PartialMedium "Medium model"
                  annotation (Dialog(group="Medium"),choicesAllMatching = true);
 
@@ -19,14 +19,14 @@ model BufferStorage
   parameter Boolean useHeatingCoil2=true "Use Heating Coil2?" annotation(Dialog(tab="Heating Coils and Rod"));
   parameter Boolean useHeatingRod=true "Use Heating Rod?" annotation(Dialog(tab="Heating Coils and Rod"));
 
-  inner parameter SI.Temperature TStart=298.15 "Start Temperature of fluid" annotation (Dialog(tab="Initialisation"));
+  parameter SI.Temperature TStart=298.15 "Start Temperature of fluid" annotation (Dialog(tab="Initialisation"));
 
-  inner parameter AixLib.DataBase.Storage.BufferStorageBaseDataDefinition data=
+  parameter AixLib.DataBase.Storage.BufferStorageBaseDataDefinition data=
     AixLib.DataBase.Storage.Generic_500l()
     "Data record for Storage"
   annotation (choicesAllMatching);
 
-  inner parameter Integer n(min=3)=5 " Model assumptions Number of Layers";
+  parameter Integer n(min=3)=5 " Model assumptions Number of Layers";
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 /////////////CONVECTION/////////////////////////////////////////////////////////////////////////////
@@ -136,7 +136,8 @@ model BufferStorage
     annotation (Placement(transformation(extent={{-6,0},{14,20}})));
     replaceable model HeatTransfer =
       AixLib.Fluid.Storage.BaseClasses.HeatTransferOnlyConduction
-    constrainedby AixLib.Fluid.Storage.BaseClasses.PartialHeatTransferLayers
+    constrainedby AixLib.Fluid.Storage.BaseClasses.PartialHeatTransferLayers(n=n,
+      redeclare package Medium = Medium, data=data)
     "Heat Transfer Model between fluid layers" annotation (choicesAllMatching=
         true);
 
@@ -244,7 +245,8 @@ model BufferStorage
     lengthHC=data.lengthHC1,
     pipeHC=data.pipeHC1,
     allowFlowReversal=true,
-    m_flow_nominal=0.05) if   useHeatingCoil1 annotation (Placement(
+    m_flow_nominal=0.05,
+    TStart=TStart) if         useHeatingCoil1 annotation (Placement(
         transformation(
         extent={{-10,-10},{10,10}},
         rotation=270,
@@ -256,7 +258,8 @@ model BufferStorage
     pipeHC=data.pipeHC2,
     redeclare package Medium = MediumHC2,
     allowFlowReversal=true,
-    m_flow_nominal=0.05) if                  useHeatingCoil2 annotation (
+    m_flow_nominal=0.05,
+    TStart=TStart) if                        useHeatingCoil2 annotation (
       Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=270,
@@ -665,7 +668,7 @@ end if;
           visible = useHeatingRod,
           thickness=2)}),
                  Diagram(coordinateSystem(preserveAspectRatio=false,
-          extent={{-80,-100},{80,100}}), graphics),
+          extent={{-80,-100},{80,100}})),
     Documentation(revisions="<html>
 <ul>
 <li><i>October 12, 2016&nbsp;</i> by Marcus Fuchs:<br/>Add comments and fix documentation</li>


### PR DESCRIPTION
see #345 

Deletions of unnecessary `inner/outer` prefixes and passing through the related parameters to particular submodels.