### PR TITLE
Add first version of github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,15 @@
+> Just stopping by to let us know about some issue you encountered with AixLib? Please feel free to delete all of this text and tell us what you think!
+
+> If you want to suggest larger changes and/or adding new models to AixLib, please make sure to briefly answer the following few questions. For more information on how to contribute to AixLib, see our [Wiki](https://github.com/RWTH-EBC/AixLib/wiki). Before submitting the issue, you can delete these first lines. Thanks for contributing!
+
+## What is the problem?
+
+- ...
+
+## Why do we want to solve it?
+
+- ...
+
+## How do we want to solve it?
+
+- ...

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+> Thank you for making a Pull Request to AixLib!
+
+> Please consider these points before submitting:
+> - Mention the issue that this Pull Request intends to solve, and briefly describe what the main changes are.
+> - Make sure all new code follows our [Modelica Guidelines](https://github.com/RWTH-EBC/AixLib/wiki/Modelica-guidelines)
+> - Make sure all new models include documentation as described in the [Documentation Wiki-Page](https://github.com/RWTH-EBC/AixLib/wiki/Documentation) and are demonstrated by suitable examples
+
+> If you know someone who could review your code, please use the *Reviewer* function on the right to ask for a review and also assign the PR to them. If not, no worries, we will find someone for you.
+
+> Thanks again for your PR! You can delete these first lines before submitting your PR.


### PR DESCRIPTION
Closes #358.

This pull request adds templates for issues and pull requests to help people contribute to AixLib and improve our workflow. As this makes no changes to AixLib's code base, I think it is OK to merge this directly into master without changing the version number. Once this is on the master, all issues and pull requests will include the template texts automatically.

Would be interesting to get feedback on this from people with different levels of experience, therefore I am asking @mlauster  and @alexanderAKU for reviews. Of course, all further feedback is also highly welcome. Once both reviews are positive, I would invite @alexanderAKU to merge this.