### PR TITLE
Heat losses in HeatPumpDetailed

### DIFF
--- a/AixLib/Fluid/HeatPumps/HeatPumpDetailed.mo
+++ b/AixLib/Fluid/HeatPumps/HeatPumpDetailed.mo
@@ -344,11 +344,13 @@ equation
 
   if heatLosses_con then
     connect(T_ambInternal, T_amb);
+    connect(heatConv.port_b, condenser.heatPort);
   else
-    connect(varTemp.T, dummyZero.y);
+    connect(T_ambInternal, dummyZero.y);
   end if;
   connect(varTemp.T, T_ambInternal);
-  connect(varTemp.port, heatConv.port_a);
+  connect(varTemp.port, heatConv.port_a) annotation (Line(points={{100,86},{104,
+        86},{104,74},{74,74},{74,62},{80,62}}, color={191,0,0}));
 
   //fluid connections evaporator
   connect(T_evaOut.port_b, port_evaOut) annotation (Line(


### PR DESCRIPTION
- connect `HeatConv.port_b` to `condenser.heatPort`
- connect T_`ambInternal` to dummy insteal of `varTemp.T`
- connection `varTemp.port` to `heatConv.port_a` can be done graphically