### PR TITLE
ValveCharacteristic from Modelica library

### DIFF
--- a/AixLib/FastHVAC/Components/Valves/ThermostaticValve.mo
+++ b/AixLib/FastHVAC/Components/Valves/ThermostaticValve.mo
@@ -2,9 +2,9 @@ within AixLib.FastHVAC.Components.Valves;
 model ThermostaticValve
 
   replaceable function valveCharacteristic =
-      HVAC.Components.Valves.BaseClasses.ValveCharacteristics.linear
+      Modelica.Fluid.Valves.BaseClasses.ValveCharacteristics.linear
     constrainedby
-    HVAC.Components.Valves.BaseClasses.ValveCharacteristics.baseFun
+    Modelica.Fluid.Valves.BaseClasses.ValveCharacteristics.baseFun
     "Inherent flow characteristic"
     annotation(choicesAllMatching=true);
 


### PR DESCRIPTION
This Pull Request refers to the issue #454_FastHVAC

I replaced the valveCharacteristic of the model, because the one from the HVAC Library is missing. 