### PR TITLE
Solved debugging problem with Fluid Source model

### DIFF
--- a/AixLib/FastHVAC/BaseClasses/EnergyBalance.mo
+++ b/AixLib/FastHVAC/BaseClasses/EnergyBalance.mo
@@ -17,11 +17,11 @@ model EnergyBalance "Base class depicts energy and mass balances"
 
 equation
   // Mass and energy balances
-  enthalpyPort_a.m_flow + enthalpyPort_b.m_flow = 0;
+  enthalpyPort_a.m_flow - enthalpyPort_b.m_flow = 0;
   enthalpyPort_b.T = heatPort_a.T;
   enthalpyPort_b.h = enthalpyPort_a.c*heatPort_a.T;
   enthalpyPort_b.c = enthalpyPort_a.c;
-  heatPort_a.Q_flow = -(enthalpyPort_a.h*enthalpyPort_a.m_flow + enthalpyPort_b.h*enthalpyPort_b.m_flow);
+  heatPort_a.Q_flow = -(enthalpyPort_a.h*enthalpyPort_a.m_flow - enthalpyPort_b.h*enthalpyPort_b.m_flow);
 
   annotation (Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,
             -100},{100,100}}), graphics={Rectangle(

--- a/AixLib/FastHVAC/Components/Pumps/FluidSource.mo
+++ b/AixLib/FastHVAC/Components/Pumps/FluidSource.mo
@@ -29,7 +29,7 @@ public
     annotation (Placement(transformation(extent={{-100,-46},{-60,-6}})));
 equation
   // balances
-  enthalpyPort_b.m_flow = -m_flow " set value of outlet port ";
+  enthalpyPort_b.m_flow = m_flow " set value of outlet port ";
   enthalpyPort_b.c = cp " set value of outlet port ";
   enthalpyPort_b.T = T_fluid " set value of outlet port ";
   enthalpyPort_b.h = cp*T_fluid " set value of outlet port ";

--- a/AixLib/FastHVAC/Interfaces/EnthalpyPort.mo
+++ b/AixLib/FastHVAC/Interfaces/EnthalpyPort.mo
@@ -2,7 +2,7 @@ within AixLib.FastHVAC.Interfaces;
 partial connector EnthalpyPort "Enthalpy port for 1-dim. enthalpy transfer"
 
   Modelica.SIunits.Temperature T "Port temperature";
-  flow Modelica.SIunits.MassFlowRate m_flow
+  Modelica.SIunits.MassFlowRate m_flow
     "Mass flow rate(positive if flowing from outside into the component)";
   Modelica.SIunits.SpecificEnthalpy h "Specific enthalpy of fluid";
   Modelica.SIunits.SpecificHeatCapacity c "Constant specific heat capacity";


### PR DESCRIPTION
The problem that every error in a model which contains the FluidSource
is associated with the FluidSource has been solved.
For that the EnergyBalance model and the EnthalpyPort model are changed
so the massflow is always positiv. (no more flow variable used)
This fix is ok because in FastHvac no change of flow direction is
possible.

Conflicts:
	AixLib/FastHVAC/Components/Pumps/FluidSource.mo

