### PR TITLE
Issue546 load resource

### DIFF
--- a/AixLib/BoundaryConditions/GroundTemperature/Examples/ExampleSanFran.mo
+++ b/AixLib/BoundaryConditions/GroundTemperature/Examples/ExampleSanFran.mo
@@ -5,21 +5,21 @@ model ExampleSanFran
   Real T_min(start=300) "Keeps track of the minimum air temperature";
 
 
-  AixLib.BoundaryConditions.WeatherData.Bus    weaBus "Component to supply air 
+  AixLib.BoundaryConditions.WeatherData.Bus    weaBus "Component to supply air
   temperature" annotation (Placement(
         transformation(extent={{-90,54},{-50,94}}), iconTransformation(extent={{
             -168,6},{-148,26}})));
   Modelica.Blocks.Interfaces.RealOutput T_air "Output to show air temperature"
     annotation (Placement(transformation(extent={{140,62},{160,82}})));
-  Modelica.Blocks.Continuous.Integrator integrator "Integrates air temperature 
+  Modelica.Blocks.Continuous.Integrator integrator "Integrates air temperature
   to compute average air temperature"
     annotation (Placement(transformation(extent={{0,40},{20,60}})));
   Modelica.Blocks.Math.Division division "Division for average air temperature"
     annotation (Placement(transformation(extent={{40,20},{60,40}})));
-  Modelica.Blocks.Sources.RealExpression timeSource(y=time) "Denominator for 
+  Modelica.Blocks.Sources.RealExpression timeSource(y=time) "Denominator for
   average air temperature"
     annotation (Placement(transformation(extent={{-40,-18},{-20,2}})));
-  Modelica.Blocks.Interfaces.RealOutput T_mean "Output of average air 
+  Modelica.Blocks.Interfaces.RealOutput T_mean "Output of average air
   temperature since beginning of simulation"
     annotation (Placement(transformation(extent={{140,20},{160,40}})));
   Modelica.Blocks.Math.Max denominatorTmean
@@ -29,7 +29,7 @@ model ExampleSanFran
   to prevent division by 0 at time=0"
     annotation (Placement(transformation(extent={{-40,4},{-20,24}})));
   AixLib.BoundaryConditions.WeatherData.ReaderTMY3    weaDat(
-      computeWetBulbTemperature=false, filNam="modelica://AixLib/Resources/WeatherData/USA_CA_San.Francisco.Intl.AP.724940_TMY3.mos")
+      computeWetBulbTemperature=false, filNam=Modelica.Utilities.Files.loadResource("modelica://AixLib/Resources/weatherdata/USA_CA_San.Francisco.Intl.AP.724940_TMY3.mos"))
                                        "File reader that reads weather data"
     annotation (Placement(transformation(extent={{-40,78},{-20,98}})));
   GroundTemperatureKusuda groundTemperatureKasuda(
@@ -39,7 +39,7 @@ model ExampleSanFran
     T_mean=286.95,
     T_amp=15.49)   "Undisturbed ground temperature model"
     annotation (Placement(transformation(extent={{40,-60},{60,-40}})));
-  Modelica.Blocks.Interfaces.RealOutput T_ground "Output to show ground 
+  Modelica.Blocks.Interfaces.RealOutput T_ground "Output to show ground
   temperature"
     annotation (Placement(transformation(extent={{140,-56},{160,-36}})));
   Modelica.Thermal.HeatTransfer.Sensors.TemperatureSensor temperatureSensor "Sensor
@@ -90,7 +90,7 @@ equation
 </html>", info="<html>
 <p>Example to test and tune Kusuda ground temperature model with the weather model from the Modelica Buildings Library.</p>
 
-<p>The outputs T, T<sub>amp</sub> and T<sub>mean</sub> in the top of the model can be used to determine the parameters 
+<p>The outputs T, T<sub>amp</sub> and T<sub>mean</sub> in the top of the model can be used to determine the parameters
 t<sub>shift</sub> (day of the coldest air temperature in the year), T<sub>mean</sub> (average air temperature in the year)
  and T<sub>amp</sub> (amplitude of the air temperature) for the Kusuda ground temperature model. </p>
 

--- a/AixLib/Controls/HVACAgentBasedControl/Examples/BuildingHeatingSystems/BuildingHeating.mo
+++ b/AixLib/Controls/HVACAgentBasedControl/Examples/BuildingHeatingSystems/BuildingHeating.mo
@@ -144,7 +144,7 @@ model BuildingHeating
   BoundaryConditions.WeatherData.ReaderTMY3        weaDat(
     calTSky=AixLib.BoundaryConditions.Types.SkyTemperatureCalculation.HorizontalRadiation,
     computeWetBulbTemperature=false,
-    filNam="modelica://AixLib/Resources/weatherdata/USA_CA_San.Francisco.Intl.AP.724940_TMY3.mos")
+    filNam=Modelica.Utilities.Files.loadResource("modelica://AixLib/Resources/weatherdata/USA_CA_San.Francisco.Intl.AP.724940_TMY3.mos"))
     "Weather data reader"
     annotation (Placement(transformation(extent={{-122,92},{-102,112}})));
   inner Modelica.Fluid.System system

--- a/AixLib/Controls/HVACAgentBasedControl/Examples/BuildingHeatingSystems/BuildingWithPV.mo
+++ b/AixLib/Controls/HVACAgentBasedControl/Examples/BuildingHeatingSystems/BuildingWithPV.mo
@@ -164,7 +164,7 @@ model BuildingWithPV
   BoundaryConditions.WeatherData.ReaderTMY3        weaDat(
     calTSky=AixLib.BoundaryConditions.Types.SkyTemperatureCalculation.HorizontalRadiation,
     computeWetBulbTemperature=false,
-    filNam="modelica://AixLib/Resources/weatherdata/USA_CA_San.Francisco.Intl.AP.724940_TMY3.mos")
+    filNam=Modelica.Utilities.Files.loadResource("modelica://AixLib/Resources/weatherdata/USA_CA_San.Francisco.Intl.AP.724940_TMY3.mos"))
     "Weather data reader"
     annotation (Placement(transformation(extent={{-60,118},{-40,138}})));
   ThermalZones.ReducedOrder.ThermalZone.ThermalZone

--- a/AixLib/ThermalZones/ReducedOrder/Examples/Multizone.mo
+++ b/AixLib/ThermalZones/ReducedOrder/Examples/Multizone.mo
@@ -25,7 +25,7 @@ model Multizone "Illustrates the use of Multizone"
     weaDat(
     calTSky=AixLib.BoundaryConditions.Types.SkyTemperatureCalculation.HorizontalRadiation,
     computeWetBulbTemperature=false,
-    filNam="modelica://AixLib/Resources/WeatherData/USA_CA_San.Francisco.Intl.AP.724940_TMY3.mos")
+    filNam=Modelica.Utilities.Files.loadResource("modelica://AixLib/Resources/weatherdata/USA_CA_San.Francisco.Intl.AP.724940_TMY3.mos"))
     "Weather data reader"
     annotation (Placement(transformation(extent={{-82,30},{-62,50}})));
   AixLib.BoundaryConditions.WeatherData.Bus weaBus

--- a/AixLib/ThermalZones/ReducedOrder/Examples/MultizoneEquipped.mo
+++ b/AixLib/ThermalZones/ReducedOrder/Examples/MultizoneEquipped.mo
@@ -37,7 +37,7 @@ model MultizoneEquipped "Illustrates the use of MultizoneEquipped"
   AixLib.BoundaryConditions.WeatherData.ReaderTMY3 weaDat(
     calTSky=AixLib.BoundaryConditions.Types.SkyTemperatureCalculation.HorizontalRadiation,
     computeWetBulbTemperature=false,
-    filNam="modelica://AixLib/Resources/WeatherData/USA_CA_San.Francisco.Intl.AP.724940_TMY3.mos")
+    filNam=Modelica.Utilities.Files.loadResource("modelica://AixLib/Resources/weatherdata/USA_CA_San.Francisco.Intl.AP.724940_TMY3.mos"))
     "Weather data reader"
     annotation (Placement(transformation(extent={{-82,30},{-62,50}})));
   Modelica.Blocks.Sources.CombiTimeTable tableInternalGains(

--- a/AixLib/ThermalZones/ReducedOrder/Examples/ThermalZone.mo
+++ b/AixLib/ThermalZones/ReducedOrder/Examples/ThermalZone.mo
@@ -14,7 +14,7 @@ model ThermalZone "Illustrates the use of ThermalZone"
   AixLib.BoundaryConditions.WeatherData.ReaderTMY3 weaDat(
     calTSky=AixLib.BoundaryConditions.Types.SkyTemperatureCalculation.HorizontalRadiation,
     computeWetBulbTemperature=false,
-    filNam="modelica://AixLib/Resources/WeatherData/USA_CA_San.Francisco.Intl.AP.724940_TMY3.mos")
+    filNam=Modelica.Utilities.Files.loadResource("modelica://AixLib/Resources/weatherdata/USA_CA_San.Francisco.Intl.AP.724940_TMY3.mos"))
     "Weather data reader"
     annotation (Placement(transformation(extent={{-92,20},{-72,40}})));
   AixLib.BoundaryConditions.WeatherData.Bus weaBus

--- a/AixLib/ThermalZones/ReducedOrder/Examples/ThermalZoneEquipped.mo
+++ b/AixLib/ThermalZones/ReducedOrder/Examples/ThermalZoneEquipped.mo
@@ -15,7 +15,7 @@ model ThermalZoneEquipped
   AixLib.BoundaryConditions.WeatherData.ReaderTMY3 weaDat(
     calTSky=AixLib.BoundaryConditions.Types.SkyTemperatureCalculation.HorizontalRadiation,
     computeWetBulbTemperature=false,
-    filNam="modelica://AixLib/Resources/WeatherData/USA_CA_San.Francisco.Intl.AP.724940_TMY3.mos")
+    filNam=Modelica.Utilities.Files.loadResource("modelica://AixLib/Resources/weatherdata/USA_CA_San.Francisco.Intl.AP.724940_TMY3.mos"))
     "Weather data reader"
     annotation (Placement(transformation(extent={{-92,20},{-72,40}})));
   AixLib.BoundaryConditions.WeatherData.Bus weaBus

--- a/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/FourElements/TestCase600.mo
+++ b/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/FourElements/TestCase600.mo
@@ -14,7 +14,7 @@ model TestCase600 "Test case 600"
     TDryBulSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HInfHorSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HSou=AixLib.BoundaryConditions.Types.RadiationDataSource.Input_HDirNor_HGloHor,
-    filNam="modelica://AixLib/Resources/WeatherData/ASHRAE140.mos")
+    filNam=Modelica.Utilities.Files.loadResource("modelica://AixLib/Resources/WeatherData/ASHRAE140.mos"))
     "Weather data reader"
     annotation (Placement(transformation(extent={{-98,68},{-78,88}})));
   AixLib.BoundaryConditions.SolarIrradiation.DiffusePerez HDifTil[4](

--- a/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/FourElements/TestCase600FF.mo
+++ b/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/FourElements/TestCase600FF.mo
@@ -11,7 +11,7 @@ model TestCase600FF "Test case 600 free floating"
     TDryBulSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HInfHorSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HSou=AixLib.BoundaryConditions.Types.RadiationDataSource.Input_HDirNor_HGloHor,
-    filNam="modelica://AixLib/Resources/WeatherData/ASHRAE140.mos")
+    filNam=Modelica.Utilities.Files.loadResource("modelica://AixLib/Resources/WeatherData/ASHRAE140.mos"))
     "Weather data reader"
     annotation (Placement(transformation(extent={{-98,68},{-78,88}})));
   AixLib.BoundaryConditions.SolarIrradiation.DiffusePerez HDifTil[4](

--- a/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/FourElements/TestCase620.mo
+++ b/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/FourElements/TestCase620.mo
@@ -14,7 +14,7 @@ model TestCase620 "Test case 620"
     TDryBulSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HInfHorSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HSou=AixLib.BoundaryConditions.Types.RadiationDataSource.Input_HDirNor_HGloHor,
-    filNam="modelica://AixLib/Resources/WeatherData/ASHRAE140.mos")
+    filNam=Modelica.Utilities.Files.loadResource("modelica://AixLib/Resources/WeatherData/ASHRAE140.mos"))
     "Weather data reader"
     annotation (Placement(transformation(extent={{-98,68},{-78,88}})));
   AixLib.BoundaryConditions.SolarIrradiation.DiffusePerez HDifTil[4](

--- a/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/FourElements/TestCase640.mo
+++ b/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/FourElements/TestCase640.mo
@@ -14,7 +14,7 @@ model TestCase640 "Test case 640"
     TDryBulSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HInfHorSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HSou=AixLib.BoundaryConditions.Types.RadiationDataSource.Input_HDirNor_HGloHor,
-    filNam="modelica://AixLib/Resources/WeatherData/ASHRAE140.mos")
+    filNam=Modelica.Utilities.Files.loadResource("modelica://AixLib/Resources/WeatherData/ASHRAE140.mos"))
     "Weather data reader"
     annotation (Placement(transformation(extent={{-98,68},{-78,88}})));
   AixLib.BoundaryConditions.SolarIrradiation.DiffusePerez HDifTil[4](

--- a/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/FourElements/TestCase650.mo
+++ b/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/FourElements/TestCase650.mo
@@ -12,7 +12,7 @@ model TestCase650 "Test case 650"
     TDryBulSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HInfHorSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HSou=AixLib.BoundaryConditions.Types.RadiationDataSource.Input_HDirNor_HGloHor,
-    filNam="modelica://AixLib/Resources/WeatherData/ASHRAE140.mos")
+    filNam=Modelica.Utilities.Files.loadResource("modelica://AixLib/Resources/WeatherData/ASHRAE140.mos"))
     "Weather data reader"
     annotation (Placement(transformation(extent={{-98,68},{-78,88}})));
   AixLib.BoundaryConditions.SolarIrradiation.DiffusePerez HDifTil[4](

--- a/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/FourElements/TestCase650FF.mo
+++ b/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/FourElements/TestCase650FF.mo
@@ -11,7 +11,7 @@ model TestCase650FF "Test case 650 free float"
     TDryBulSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HInfHorSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HSou=AixLib.BoundaryConditions.Types.RadiationDataSource.Input_HDirNor_HGloHor,
-    filNam="modelica://AixLib/Resources/WeatherData/ASHRAE140.mos")
+    filNam=Modelica.Utilities.Files.loadResource("modelica://AixLib/Resources/WeatherData/ASHRAE140.mos"))
     "Weather data reader"
     annotation (Placement(transformation(extent={{-98,68},{-78,88}})));
   AixLib.BoundaryConditions.SolarIrradiation.DiffusePerez HDifTil[4](

--- a/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/FourElements/TestCase900.mo
+++ b/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/FourElements/TestCase900.mo
@@ -14,7 +14,7 @@ model TestCase900 "Test case 900"
     TDryBulSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HInfHorSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HSou=AixLib.BoundaryConditions.Types.RadiationDataSource.Input_HDirNor_HGloHor,
-    filNam="modelica://AixLib/Resources/WeatherData/ASHRAE140.mos")
+    filNam=Modelica.Utilities.Files.loadResource("modelica://AixLib/Resources/WeatherData/ASHRAE140.mos"))
     "Weather data reader"
     annotation (Placement(transformation(extent={{-98,68},{-78,88}})));
   AixLib.BoundaryConditions.SolarIrradiation.DiffusePerez HDifTil[4](

--- a/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/FourElements/TestCase900FF.mo
+++ b/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/FourElements/TestCase900FF.mo
@@ -11,7 +11,7 @@ model TestCase900FF "Test case 900 free floating"
     TDryBulSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HInfHorSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HSou=AixLib.BoundaryConditions.Types.RadiationDataSource.Input_HDirNor_HGloHor,
-    filNam="modelica://AixLib/Resources/WeatherData/ASHRAE140.mos")
+    filNam=Modelica.Utilities.Files.loadResource("modelica://AixLib/Resources/WeatherData/ASHRAE140.mos"))
     "Weather data reader"
     annotation (Placement(transformation(extent={{-98,68},{-78,88}})));
   AixLib.BoundaryConditions.SolarIrradiation.DiffusePerez HDifTil[4](

--- a/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/FourElements/TestCase920.mo
+++ b/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/FourElements/TestCase920.mo
@@ -14,7 +14,7 @@ model TestCase920 "Test case 920"
     TDryBulSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HInfHorSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HSou=AixLib.BoundaryConditions.Types.RadiationDataSource.Input_HDirNor_HGloHor,
-    filNam="modelica://AixLib/Resources/WeatherData/ASHRAE140.mos")
+    filNam=Modelica.Utilities.Files.loadResource("modelica://AixLib/Resources/WeatherData/ASHRAE140.mos"))
     "Weather data reader"
     annotation (Placement(transformation(extent={{-98,68},{-78,88}})));
   AixLib.BoundaryConditions.SolarIrradiation.DiffusePerez HDifTil[4](

--- a/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/FourElements/TestCase940.mo
+++ b/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/FourElements/TestCase940.mo
@@ -14,7 +14,7 @@ model TestCase940 "Test case 940"
     TDryBulSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HInfHorSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HSou=AixLib.BoundaryConditions.Types.RadiationDataSource.Input_HDirNor_HGloHor,
-    filNam="modelica://AixLib/Resources/WeatherData/ASHRAE140.mos")
+    filNam=Modelica.Utilities.Files.loadResource("modelica://AixLib/Resources/WeatherData/ASHRAE140.mos"))
     "Weather data reader"
     annotation (Placement(transformation(extent={{-98,68},{-78,88}})));
   AixLib.BoundaryConditions.SolarIrradiation.DiffusePerez HDifTil[4](

--- a/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/FourElements/TestCase950.mo
+++ b/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/FourElements/TestCase950.mo
@@ -12,7 +12,7 @@ model TestCase950 "Test case 950"
     TDryBulSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HInfHorSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HSou=AixLib.BoundaryConditions.Types.RadiationDataSource.Input_HDirNor_HGloHor,
-    filNam="modelica://AixLib/Resources/WeatherData/ASHRAE140.mos")
+    filNam=Modelica.Utilities.Files.loadResource("modelica://AixLib/Resources/WeatherData/ASHRAE140.mos"))
     "Weather data reader"
     annotation (Placement(transformation(extent={{-98,68},{-78,88}})));
   AixLib.BoundaryConditions.SolarIrradiation.DiffusePerez HDifTil[4](

--- a/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/FourElements/TestCase950FF.mo
+++ b/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/FourElements/TestCase950FF.mo
@@ -11,7 +11,7 @@ model TestCase950FF "Test case 950 free float"
     TDryBulSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HInfHorSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HSou=AixLib.BoundaryConditions.Types.RadiationDataSource.Input_HDirNor_HGloHor,
-    filNam="modelica://AixLib/Resources/WeatherData/ASHRAE140.mos")
+    filNam=Modelica.Utilities.Files.loadResource("modelica://AixLib/Resources/WeatherData/ASHRAE140.mos"))
     "Weather data reader"
     annotation (Placement(transformation(extent={{-98,68},{-78,88}})));
   AixLib.BoundaryConditions.SolarIrradiation.DiffusePerez HDifTil[4](

--- a/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/OneElement/TestCase600.mo
+++ b/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/OneElement/TestCase600.mo
@@ -14,7 +14,7 @@ model TestCase600 "Test case 600"
     TDryBulSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HInfHorSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HSou=AixLib.BoundaryConditions.Types.RadiationDataSource.Input_HDirNor_HGloHor,
-    filNam="modelica://AixLib/Resources/WeatherData/ASHRAE140.mos")
+    filNam=Modelica.Utilities.Files.loadResource("modelica://AixLib/Resources/WeatherData/ASHRAE140.mos"))
     "Weather data reader"
     annotation (Placement(transformation(extent={{-98,68},{-78,88}})));
   AixLib.BoundaryConditions.SolarIrradiation.DiffusePerez HDifTil[5](

--- a/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/OneElement/TestCase600FF.mo
+++ b/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/OneElement/TestCase600FF.mo
@@ -11,7 +11,7 @@ model TestCase600FF "Test case 600 free floating"
     TDryBulSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HInfHorSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HSou=AixLib.BoundaryConditions.Types.RadiationDataSource.Input_HDirNor_HGloHor,
-    filNam="modelica://AixLib/Resources/WeatherData/ASHRAE140.mos")
+    filNam=Modelica.Utilities.Files.loadResource("modelica://AixLib/Resources/WeatherData/ASHRAE140.mos"))
     "Weather data reader"
     annotation (Placement(transformation(extent={{-98,68},{-78,88}})));
   AixLib.BoundaryConditions.SolarIrradiation.DiffusePerez HDifTil[5](

--- a/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/OneElement/TestCase620.mo
+++ b/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/OneElement/TestCase620.mo
@@ -14,7 +14,7 @@ model TestCase620 "Test case 620"
     TDryBulSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HInfHorSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HSou=AixLib.BoundaryConditions.Types.RadiationDataSource.Input_HDirNor_HGloHor,
-    filNam="modelica://AixLib/Resources/WeatherData/ASHRAE140.mos")
+    filNam=Modelica.Utilities.Files.loadResource("modelica://AixLib/Resources/WeatherData/ASHRAE140.mos"))
     "Weather data reader"
     annotation (Placement(transformation(extent={{-98,68},{-78,88}})));
   AixLib.BoundaryConditions.SolarIrradiation.DiffusePerez HDifTil[5](

--- a/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/OneElement/TestCase640.mo
+++ b/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/OneElement/TestCase640.mo
@@ -14,7 +14,7 @@ model TestCase640 "Test case 640"
     TDryBulSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HInfHorSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HSou=AixLib.BoundaryConditions.Types.RadiationDataSource.Input_HDirNor_HGloHor,
-    filNam="modelica://AixLib/Resources/WeatherData/ASHRAE140.mos")
+    filNam=Modelica.Utilities.Files.loadResource("modelica://AixLib/Resources/WeatherData/ASHRAE140.mos"))
     "Weather data reader"
     annotation (Placement(transformation(extent={{-98,68},{-78,88}})));
   AixLib.BoundaryConditions.SolarIrradiation.DiffusePerez HDifTil[5](

--- a/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/OneElement/TestCase650.mo
+++ b/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/OneElement/TestCase650.mo
@@ -12,7 +12,7 @@ model TestCase650 "Test case 650"
     TDryBulSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HInfHorSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HSou=AixLib.BoundaryConditions.Types.RadiationDataSource.Input_HDirNor_HGloHor,
-    filNam="modelica://AixLib/Resources/WeatherData/ASHRAE140.mos")
+    filNam=Modelica.Utilities.Files.loadResource("modelica://AixLib/Resources/WeatherData/ASHRAE140.mos"))
     "Weather data reader"
     annotation (Placement(transformation(extent={{-98,68},{-78,88}})));
   AixLib.BoundaryConditions.SolarIrradiation.DiffusePerez HDifTil[5](

--- a/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/OneElement/TestCase650FF.mo
+++ b/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/OneElement/TestCase650FF.mo
@@ -11,7 +11,7 @@ model TestCase650FF "Test case 650 free float"
     TDryBulSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HInfHorSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HSou=AixLib.BoundaryConditions.Types.RadiationDataSource.Input_HDirNor_HGloHor,
-    filNam="modelica://AixLib/Resources/WeatherData/ASHRAE140.mos")
+    filNam=Modelica.Utilities.Files.loadResource("modelica://AixLib/Resources/WeatherData/ASHRAE140.mos"))
     "Weather data reader"
     annotation (Placement(transformation(extent={{-98,68},{-78,88}})));
   AixLib.BoundaryConditions.SolarIrradiation.DiffusePerez HDifTil[5](

--- a/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/OneElement/TestCase900.mo
+++ b/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/OneElement/TestCase900.mo
@@ -14,7 +14,7 @@ model TestCase900 "Test case 900"
     TDryBulSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HInfHorSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HSou=AixLib.BoundaryConditions.Types.RadiationDataSource.Input_HDirNor_HGloHor,
-    filNam="modelica://AixLib/Resources/WeatherData/ASHRAE140.mos")
+    filNam=Modelica.Utilities.Files.loadResource("modelica://AixLib/Resources/WeatherData/ASHRAE140.mos"))
     "Weather data reader"
     annotation (Placement(transformation(extent={{-98,68},{-78,88}})));
   AixLib.BoundaryConditions.SolarIrradiation.DiffusePerez HDifTil[5](

--- a/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/OneElement/TestCase900FF.mo
+++ b/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/OneElement/TestCase900FF.mo
@@ -11,7 +11,7 @@ model TestCase900FF "Test case 900 free floating"
     TDryBulSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HInfHorSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HSou=AixLib.BoundaryConditions.Types.RadiationDataSource.Input_HDirNor_HGloHor,
-    filNam="modelica://AixLib/Resources/WeatherData/ASHRAE140.mos")
+    filNam=Modelica.Utilities.Files.loadResource("modelica://AixLib/Resources/WeatherData/ASHRAE140.mos"))
     "Weather data reader"
     annotation (Placement(transformation(extent={{-98,68},{-78,88}})));
   AixLib.BoundaryConditions.SolarIrradiation.DiffusePerez HDifTil[5](

--- a/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/OneElement/TestCase920.mo
+++ b/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/OneElement/TestCase920.mo
@@ -10,7 +10,7 @@ model TestCase920 "Test case 920"
     TDryBulSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HInfHorSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HSou=AixLib.BoundaryConditions.Types.RadiationDataSource.Input_HDirNor_HGloHor,
-    filNam="modelica://AixLib/Resources/WeatherData/ASHRAE140.mos")
+    filNam=Modelica.Utilities.Files.loadResource("modelica://AixLib/Resources/WeatherData/ASHRAE140.mos"))
     "Weather data reader"
     annotation (Placement(transformation(extent={{-98,68},{-78,88}})));
   AixLib.BoundaryConditions.SolarIrradiation.DiffusePerez HDifTil[5](

--- a/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/OneElement/TestCase940.mo
+++ b/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/OneElement/TestCase940.mo
@@ -10,7 +10,7 @@ model TestCase940 "Test case 940"
     TDryBulSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HInfHorSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HSou=AixLib.BoundaryConditions.Types.RadiationDataSource.Input_HDirNor_HGloHor,
-    filNam="modelica://AixLib/Resources/WeatherData/ASHRAE140.mos")
+    filNam=Modelica.Utilities.Files.loadResource("modelica://AixLib/Resources/WeatherData/ASHRAE140.mos"))
     "Weather data reader"
     annotation (Placement(transformation(extent={{-98,68},{-78,88}})));
   AixLib.BoundaryConditions.SolarIrradiation.DiffusePerez HDifTil[5](

--- a/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/OneElement/TestCase950.mo
+++ b/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/OneElement/TestCase950.mo
@@ -12,7 +12,7 @@ model TestCase950 "Test case 950"
     TDryBulSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HInfHorSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HSou=AixLib.BoundaryConditions.Types.RadiationDataSource.Input_HDirNor_HGloHor,
-    filNam="modelica://AixLib/Resources/WeatherData/ASHRAE140.mos")
+    filNam=Modelica.Utilities.Files.loadResource("modelica://AixLib/Resources/WeatherData/ASHRAE140.mos"))
     "Weather data reader"
     annotation (Placement(transformation(extent={{-98,68},{-78,88}})));
   AixLib.BoundaryConditions.SolarIrradiation.DiffusePerez HDifTil[5](

--- a/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/OneElement/TestCase950FF.mo
+++ b/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/OneElement/TestCase950FF.mo
@@ -11,7 +11,7 @@ model TestCase950FF "Test case 950 free float"
     TDryBulSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HInfHorSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HSou=AixLib.BoundaryConditions.Types.RadiationDataSource.Input_HDirNor_HGloHor,
-    filNam="modelica://AixLib/Resources/WeatherData/ASHRAE140.mos")
+    filNam=Modelica.Utilities.Files.loadResource("modelica://AixLib/Resources/WeatherData/ASHRAE140.mos"))
     "Weather data reader"
     annotation (Placement(transformation(extent={{-98,68},{-78,88}})));
   AixLib.BoundaryConditions.SolarIrradiation.DiffusePerez HDifTil[5](

--- a/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/ThreeElements/TestCase600.mo
+++ b/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/ThreeElements/TestCase600.mo
@@ -14,7 +14,7 @@ model TestCase600 "Test case 600"
     TDryBulSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HInfHorSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HSou=AixLib.BoundaryConditions.Types.RadiationDataSource.Input_HDirNor_HGloHor,
-    filNam="modelica://AixLib/Resources/WeatherData/ASHRAE140.mos")
+    filNam=Modelica.Utilities.Files.loadResource("modelica://AixLib/Resources/WeatherData/ASHRAE140.mos"))
     "Weather data reader"
     annotation (Placement(transformation(extent={{-98,68},{-78,88}})));
   AixLib.BoundaryConditions.SolarIrradiation.DiffusePerez HDifTil[5](

--- a/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/ThreeElements/TestCase600FF.mo
+++ b/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/ThreeElements/TestCase600FF.mo
@@ -11,7 +11,7 @@ model TestCase600FF "Test case 600 free floating"
     TDryBulSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HInfHorSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HSou=AixLib.BoundaryConditions.Types.RadiationDataSource.Input_HDirNor_HGloHor,
-    filNam="modelica://AixLib/Resources/WeatherData/ASHRAE140.mos")
+    filNam=Modelica.Utilities.Files.loadResource("modelica://AixLib/Resources/WeatherData/ASHRAE140.mos"))
     "Weather data reader"
     annotation (Placement(transformation(extent={{-98,68},{-78,88}})));
   AixLib.BoundaryConditions.SolarIrradiation.DiffusePerez HDifTil[5](

--- a/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/ThreeElements/TestCase620.mo
+++ b/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/ThreeElements/TestCase620.mo
@@ -14,7 +14,7 @@ model TestCase620 "Test case 620"
     TDryBulSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HInfHorSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HSou=AixLib.BoundaryConditions.Types.RadiationDataSource.Input_HDirNor_HGloHor,
-    filNam="modelica://AixLib/Resources/WeatherData/ASHRAE140.mos")
+    filNam=Modelica.Utilities.Files.loadResource("modelica://AixLib/Resources/WeatherData/ASHRAE140.mos"))
     "Weather data reader"
     annotation (Placement(transformation(extent={{-98,68},{-78,88}})));
   AixLib.BoundaryConditions.SolarIrradiation.DiffusePerez HDifTil[5](

--- a/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/ThreeElements/TestCase640.mo
+++ b/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/ThreeElements/TestCase640.mo
@@ -14,7 +14,7 @@ model TestCase640 "Test case 640"
     TDryBulSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HInfHorSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HSou=AixLib.BoundaryConditions.Types.RadiationDataSource.Input_HDirNor_HGloHor,
-    filNam="modelica://AixLib/Resources/WeatherData/ASHRAE140.mos")
+    filNam=Modelica.Utilities.Files.loadResource("modelica://AixLib/Resources/WeatherData/ASHRAE140.mos"))
     "Weather data reader"
     annotation (Placement(transformation(extent={{-98,68},{-78,88}})));
   AixLib.BoundaryConditions.SolarIrradiation.DiffusePerez HDifTil[5](

--- a/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/ThreeElements/TestCase650.mo
+++ b/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/ThreeElements/TestCase650.mo
@@ -12,7 +12,7 @@ model TestCase650 "Test case 650"
     TDryBulSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HInfHorSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HSou=AixLib.BoundaryConditions.Types.RadiationDataSource.Input_HDirNor_HGloHor,
-    filNam="modelica://AixLib/Resources/WeatherData/ASHRAE140.mos")
+    filNam=Modelica.Utilities.Files.loadResource("modelica://AixLib/Resources/WeatherData/ASHRAE140.mos"))
     "Weather data reader"
     annotation (Placement(transformation(extent={{-98,68},{-78,88}})));
   AixLib.BoundaryConditions.SolarIrradiation.DiffusePerez HDifTil[5](

--- a/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/ThreeElements/TestCase650FF.mo
+++ b/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/ThreeElements/TestCase650FF.mo
@@ -11,7 +11,7 @@ model TestCase650FF "Test case 650 free float"
     TDryBulSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HInfHorSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HSou=AixLib.BoundaryConditions.Types.RadiationDataSource.Input_HDirNor_HGloHor,
-    filNam="modelica://AixLib/Resources/WeatherData/ASHRAE140.mos")
+    filNam=Modelica.Utilities.Files.loadResource("modelica://AixLib/Resources/WeatherData/ASHRAE140.mos"))
     "Weather data reader"
     annotation (Placement(transformation(extent={{-98,68},{-78,88}})));
   AixLib.BoundaryConditions.SolarIrradiation.DiffusePerez HDifTil[5](

--- a/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/ThreeElements/TestCase900.mo
+++ b/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/ThreeElements/TestCase900.mo
@@ -14,7 +14,7 @@ model TestCase900 "Test case 900"
     TDryBulSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HInfHorSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HSou=AixLib.BoundaryConditions.Types.RadiationDataSource.Input_HDirNor_HGloHor,
-    filNam="modelica://AixLib/Resources/WeatherData/ASHRAE140.mos")
+    filNam=Modelica.Utilities.Files.loadResource("modelica://AixLib/Resources/WeatherData/ASHRAE140.mos"))
     "Weather data reader"
     annotation (Placement(transformation(extent={{-98,68},{-78,88}})));
   AixLib.BoundaryConditions.SolarIrradiation.DiffusePerez HDifTil[5](

--- a/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/ThreeElements/TestCase900FF.mo
+++ b/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/ThreeElements/TestCase900FF.mo
@@ -11,7 +11,7 @@ model TestCase900FF "Test case 900 free floating"
     TDryBulSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HInfHorSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HSou=AixLib.BoundaryConditions.Types.RadiationDataSource.Input_HDirNor_HGloHor,
-    filNam="modelica://AixLib/Resources/WeatherData/ASHRAE140.mos")
+    filNam=Modelica.Utilities.Files.loadResource("modelica://AixLib/Resources/WeatherData/ASHRAE140.mos"))
     "Weather data reader"
     annotation (Placement(transformation(extent={{-98,68},{-78,88}})));
   AixLib.BoundaryConditions.SolarIrradiation.DiffusePerez HDifTil[5](

--- a/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/ThreeElements/TestCase920.mo
+++ b/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/ThreeElements/TestCase920.mo
@@ -14,7 +14,7 @@ model TestCase920 "Test case 920"
     TDryBulSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HInfHorSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HSou=AixLib.BoundaryConditions.Types.RadiationDataSource.Input_HDirNor_HGloHor,
-    filNam="modelica://AixLib/Resources/WeatherData/ASHRAE140.mos")
+    filNam=Modelica.Utilities.Files.loadResource("modelica://AixLib/Resources/WeatherData/ASHRAE140.mos"))
     "Weather data reader"
     annotation (Placement(transformation(extent={{-98,68},{-78,88}})));
   AixLib.BoundaryConditions.SolarIrradiation.DiffusePerez HDifTil[5](

--- a/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/ThreeElements/TestCase940.mo
+++ b/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/ThreeElements/TestCase940.mo
@@ -14,7 +14,7 @@ model TestCase940 "Test case 940"
     TDryBulSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HInfHorSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HSou=AixLib.BoundaryConditions.Types.RadiationDataSource.Input_HDirNor_HGloHor,
-    filNam="modelica://AixLib/Resources/WeatherData/ASHRAE140.mos")
+    filNam=Modelica.Utilities.Files.loadResource("modelica://AixLib/Resources/WeatherData/ASHRAE140.mos"))
     "Weather data reader"
     annotation (Placement(transformation(extent={{-98,68},{-78,88}})));
   AixLib.BoundaryConditions.SolarIrradiation.DiffusePerez HDifTil[5](

--- a/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/ThreeElements/TestCase950.mo
+++ b/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/ThreeElements/TestCase950.mo
@@ -12,7 +12,7 @@ model TestCase950 "Test case 950"
     TDryBulSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HInfHorSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HSou=AixLib.BoundaryConditions.Types.RadiationDataSource.Input_HDirNor_HGloHor,
-    filNam="modelica://AixLib/Resources/WeatherData/ASHRAE140.mos")
+    filNam=Modelica.Utilities.Files.loadResource("modelica://AixLib/Resources/WeatherData/ASHRAE140.mos"))
     "Weather data reader"
     annotation (Placement(transformation(extent={{-98,68},{-78,88}})));
   AixLib.BoundaryConditions.SolarIrradiation.DiffusePerez HDifTil[5](

--- a/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/ThreeElements/TestCase950FF.mo
+++ b/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/ThreeElements/TestCase950FF.mo
@@ -11,7 +11,7 @@ model TestCase950FF "Test case 950 free float"
     TDryBulSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HInfHorSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HSou=AixLib.BoundaryConditions.Types.RadiationDataSource.Input_HDirNor_HGloHor,
-    filNam="modelica://AixLib/Resources/WeatherData/ASHRAE140.mos")
+    filNam=Modelica.Utilities.Files.loadResource("modelica://AixLib/Resources/WeatherData/ASHRAE140.mos"))
     "Weather data reader"
     annotation (Placement(transformation(extent={{-98,68},{-78,88}})));
   AixLib.BoundaryConditions.SolarIrradiation.DiffusePerez HDifTil[5](

--- a/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/TwoElements/TestCase600.mo
+++ b/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/TwoElements/TestCase600.mo
@@ -27,7 +27,7 @@ model TestCase600 "Test case 600"
     TDryBulSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HInfHorSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HSou=AixLib.BoundaryConditions.Types.RadiationDataSource.Input_HDirNor_HGloHor,
-    filNam="modelica://AixLib/Resources/WeatherData/ASHRAE140.mos")
+    filNam=Modelica.Utilities.Files.loadResource("modelica://AixLib/Resources/WeatherData/ASHRAE140.mos"))
     "Weather data reader"
     annotation (Placement(transformation(extent={{-98,68},{-78,88}})));
   AixLib.BoundaryConditions.SolarIrradiation.DiffusePerez HDifTil[5](

--- a/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/TwoElements/TestCase600FF.mo
+++ b/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/TwoElements/TestCase600FF.mo
@@ -11,7 +11,7 @@ model TestCase600FF "Test case 600 free floating"
     TDryBulSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HInfHorSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HSou=AixLib.BoundaryConditions.Types.RadiationDataSource.Input_HDirNor_HGloHor,
-    filNam="modelica://AixLib/Resources/WeatherData/ASHRAE140.mos")
+    filNam=Modelica.Utilities.Files.loadResource("modelica://AixLib/Resources/WeatherData/ASHRAE140.mos"))
     "Weather data reader"
     annotation (Placement(transformation(extent={{-98,68},{-78,88}})));
   AixLib.BoundaryConditions.SolarIrradiation.DiffusePerez HDifTil[5](

--- a/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/TwoElements/TestCase620.mo
+++ b/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/TwoElements/TestCase620.mo
@@ -14,7 +14,7 @@ model TestCase620 "Test case 620"
     TDryBulSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HInfHorSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HSou=AixLib.BoundaryConditions.Types.RadiationDataSource.Input_HDirNor_HGloHor,
-    filNam="modelica://AixLib/Resources/WeatherData/ASHRAE140.mos")
+    filNam=Modelica.Utilities.Files.loadResource("modelica://AixLib/Resources/WeatherData/ASHRAE140.mos"))
     "Weather data reader"
     annotation (Placement(transformation(extent={{-98,68},{-78,88}})));
   AixLib.BoundaryConditions.SolarIrradiation.DiffusePerez HDifTil[5](

--- a/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/TwoElements/TestCase640.mo
+++ b/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/TwoElements/TestCase640.mo
@@ -14,7 +14,7 @@ model TestCase640 "Test case 640"
     TDryBulSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HInfHorSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HSou=AixLib.BoundaryConditions.Types.RadiationDataSource.Input_HDirNor_HGloHor,
-    filNam="modelica://AixLib/Resources/WeatherData/ASHRAE140.mos")
+    filNam=Modelica.Utilities.Files.loadResource("modelica://AixLib/Resources/WeatherData/ASHRAE140.mos"))
     "Weather data reader"
     annotation (Placement(transformation(extent={{-98,68},{-78,88}})));
   AixLib.BoundaryConditions.SolarIrradiation.DiffusePerez HDifTil[5](

--- a/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/TwoElements/TestCase650.mo
+++ b/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/TwoElements/TestCase650.mo
@@ -12,7 +12,7 @@ model TestCase650 "Test case 650"
     TDryBulSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HInfHorSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HSou=AixLib.BoundaryConditions.Types.RadiationDataSource.Input_HDirNor_HGloHor,
-    filNam="modelica://AixLib/Resources/WeatherData/ASHRAE140.mos")
+    filNam=Modelica.Utilities.Files.loadResource("modelica://AixLib/Resources/WeatherData/ASHRAE140.mos"))
     "Weather data reader"
     annotation (Placement(transformation(extent={{-98,68},{-78,88}})));
   AixLib.BoundaryConditions.SolarIrradiation.DiffusePerez HDifTil[5](

--- a/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/TwoElements/TestCase650FF.mo
+++ b/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/TwoElements/TestCase650FF.mo
@@ -11,7 +11,7 @@ model TestCase650FF "Test case 650 free float"
     TDryBulSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HInfHorSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HSou=AixLib.BoundaryConditions.Types.RadiationDataSource.Input_HDirNor_HGloHor,
-    filNam="modelica://AixLib/Resources/WeatherData/ASHRAE140.mos")
+    filNam=Modelica.Utilities.Files.loadResource("modelica://AixLib/Resources/WeatherData/ASHRAE140.mos"))
     "Weather data reader"
     annotation (Placement(transformation(extent={{-98,68},{-78,88}})));
   AixLib.BoundaryConditions.SolarIrradiation.DiffusePerez HDifTil[5](

--- a/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/TwoElements/TestCase900.mo
+++ b/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/TwoElements/TestCase900.mo
@@ -14,7 +14,7 @@ model TestCase900 "Test case 900"
     TDryBulSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HInfHorSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HSou=AixLib.BoundaryConditions.Types.RadiationDataSource.Input_HDirNor_HGloHor,
-    filNam="modelica://AixLib/Resources/WeatherData/ASHRAE140.mos")
+    filNam=Modelica.Utilities.Files.loadResource("modelica://AixLib/Resources/WeatherData/ASHRAE140.mos"))
     "Weather data reader"
     annotation (Placement(transformation(extent={{-98,68},{-78,88}})));
   AixLib.BoundaryConditions.SolarIrradiation.DiffusePerez HDifTil[5](

--- a/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/TwoElements/TestCase900FF.mo
+++ b/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/TwoElements/TestCase900FF.mo
@@ -11,7 +11,7 @@ model TestCase900FF "Test case 900 free floating"
     TDryBulSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HInfHorSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HSou=AixLib.BoundaryConditions.Types.RadiationDataSource.Input_HDirNor_HGloHor,
-    filNam="modelica://AixLib/Resources/WeatherData/ASHRAE140.mos")
+    filNam=Modelica.Utilities.Files.loadResource("modelica://AixLib/Resources/WeatherData/ASHRAE140.mos"))
     "Weather data reader"
     annotation (Placement(transformation(extent={{-98,68},{-78,88}})));
   AixLib.BoundaryConditions.SolarIrradiation.DiffusePerez HDifTil[5](

--- a/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/TwoElements/TestCase920.mo
+++ b/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/TwoElements/TestCase920.mo
@@ -14,7 +14,7 @@ model TestCase920 "Test case 920"
     TDryBulSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HInfHorSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HSou=AixLib.BoundaryConditions.Types.RadiationDataSource.Input_HDirNor_HGloHor,
-    filNam="modelica://AixLib/Resources/WeatherData/ASHRAE140.mos")
+    filNam=Modelica.Utilities.Files.loadResource("modelica://AixLib/Resources/WeatherData/ASHRAE140.mos"))
     "Weather data reader"
     annotation (Placement(transformation(extent={{-98,68},{-78,88}})));
   AixLib.BoundaryConditions.SolarIrradiation.DiffusePerez HDifTil[5](

--- a/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/TwoElements/TestCase940.mo
+++ b/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/TwoElements/TestCase940.mo
@@ -14,7 +14,7 @@ model TestCase940 "Test case 940"
     TDryBulSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HInfHorSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HSou=AixLib.BoundaryConditions.Types.RadiationDataSource.Input_HDirNor_HGloHor,
-    filNam="modelica://AixLib/Resources/WeatherData/ASHRAE140.mos")
+    filNam=Modelica.Utilities.Files.loadResource("modelica://AixLib/Resources/WeatherData/ASHRAE140.mos"))
     "Weather data reader"
     annotation (Placement(transformation(extent={{-98,68},{-78,88}})));
   AixLib.BoundaryConditions.SolarIrradiation.DiffusePerez HDifTil[5](

--- a/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/TwoElements/TestCase950.mo
+++ b/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/TwoElements/TestCase950.mo
@@ -12,7 +12,7 @@ model TestCase950 "Test case 950"
     TDryBulSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HInfHorSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HSou=AixLib.BoundaryConditions.Types.RadiationDataSource.Input_HDirNor_HGloHor,
-    filNam="modelica://AixLib/Resources/WeatherData/ASHRAE140.mos")
+    filNam=Modelica.Utilities.Files.loadResource("modelica://AixLib/Resources/WeatherData/ASHRAE140.mos"))
     "Weather data reader"
     annotation (Placement(transformation(extent={{-98,68},{-78,88}})));
   AixLib.BoundaryConditions.SolarIrradiation.DiffusePerez HDifTil[5](

--- a/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/TwoElements/TestCase950FF.mo
+++ b/AixLib/ThermalZones/ReducedOrder/Validation/ASHRAE140/TwoElements/TestCase950FF.mo
@@ -11,7 +11,7 @@ model TestCase950FF "Test case 950 free float"
     TDryBulSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HInfHorSou=AixLib.BoundaryConditions.Types.DataSource.Input,
     HSou=AixLib.BoundaryConditions.Types.RadiationDataSource.Input_HDirNor_HGloHor,
-    filNam="modelica://AixLib/Resources/WeatherData/ASHRAE140.mos")
+    filNam=Modelica.Utilities.Files.loadResource("modelica://AixLib/Resources/WeatherData/ASHRAE140.mos"))
     "Weather data reader"
     annotation (Placement(transformation(extent={{-98,68},{-78,88}})));
   AixLib.BoundaryConditions.SolarIrradiation.DiffusePerez HDifTil[5](

--- a/AixLib/ThermalZones/ReducedOrder/Windows/Examples/Illumination.mo
+++ b/AixLib/ThermalZones/ReducedOrder/Windows/Examples/Illumination.mo
@@ -42,7 +42,7 @@ model Illumination "Testmodel for Illumination"
     til={1.5707963267949}) "Window facing the south in a wall"
     annotation (Placement(transformation(extent={{-10,24},{10,44}})));
   AixLib.BoundaryConditions.WeatherData.ReaderTMY3 weaDat(
-    filNam="modelica://AixLib/Resources/weatherdata/USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.mos")
+    filNam=Modelica.Utilities.Files.loadResource("modelica://AixLib/Resources/weatherdata/USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.mos"))
     annotation (Placement(transformation(extent={{-100,-10},{-80,10}})));
   AixLib.BoundaryConditions.SolarIrradiation.DirectTiltedSurface HDirTil(
     azi=0,

--- a/AixLib/ThermalZones/ReducedOrder/Windows/Examples/ShadedWindow.mo
+++ b/AixLib/ThermalZones/ReducedOrder/Windows/Examples/ShadedWindow.mo
@@ -3,7 +3,7 @@ model ShadedWindow "Testmodel for ShadedWindow"
   extends Modelica.Icons.Example;
 
   AixLib.BoundaryConditions.WeatherData.ReaderTMY3 weaDat(
-    filNam="modelica://AixLib/Resources/weatherdata/USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.mos")
+    filNam=Modelica.Utilities.Files.loadResource("modelica://AixLib/Resources/weatherdata/USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.mos"))
     "Weather data for Chicago"
     annotation (Placement(transformation(extent={{-42,-10},{-22,10}})));
   AixLib.ThermalZones.ReducedOrder.Windows.ShadedWindow shadedWindow(

--- a/AixLib/ThermalZones/ReducedOrder/Windows/Examples/VentilationHeat.mo
+++ b/AixLib/ThermalZones/ReducedOrder/Windows/Examples/VentilationHeat.mo
@@ -12,7 +12,7 @@ model VentilationHeat "Testmodel for VentilationHeat"
     "Heat input due to ventilation with closed sunblind"
     annotation (Placement(transformation(extent={{56,-10},{76,10}})));
   AixLib.BoundaryConditions.WeatherData.ReaderTMY3 weaDat(
-    filNam="modelica://AixLib/Resources/weatherdata/USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.mos")
+    filNam=Modelica.Utilities.Files.loadResource("modelica://AixLib/Resources/weatherdata/USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.mos"))
     "Weather data for Chicago"
     annotation (Placement(transformation(extent={{-100,-10},{-80,10}})));
   AixLib.BoundaryConditions.SolarIrradiation.DiffusePerez HDifTil(

--- a/AixLib/ThermalZones/ReducedOrder/Windows/Examples/Window.mo
+++ b/AixLib/ThermalZones/ReducedOrder/Windows/Examples/Window.mo
@@ -3,7 +3,7 @@ model Window "Testmodel for Window"
     extends Modelica.Icons.Example;
 
   AixLib.BoundaryConditions.WeatherData.ReaderTMY3 weaDat(
-    filNam="modelica://AixLib/Resources/weatherdata/USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.mos")
+    filNam=Modelica.Utilities.Files.loadResource("modelica://AixLib/Resources/weatherdata/USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.mos"))
     "Weather data for Chicago"
     annotation (Placement(transformation(extent={{-42,-10},{-22,10}})));
   AixLib.ThermalZones.ReducedOrder.Windows.Window window(


### PR DESCRIPTION
This closes #546. In ibpsa/modelica-ibpsa#867, the weather data reader changed and longer includes the `loadResource()` call itself. Therefore, we needed to add this call to our examples.
