### PR TITLE
Issue555 Heating coil buffer storage

### DIFF
--- a/AixLib/Fluid/Storage/BufferStorage.mo
+++ b/AixLib/Fluid/Storage/BufferStorage.mo
@@ -82,7 +82,12 @@ model BufferStorage
   Modelica.Thermal.HeatTransfer.Interfaces.HeatPort_a heatportOutside "Outer heat port"
     annotation (Placement(transformation(extent={{68,-4},{88,16}},rotation=0),
         iconTransformation(extent={{68,-4},{88,16}})));
-  Modelica.Blocks.Interfaces.RealOutput TTop "Temperature at the top"
+  Modelica.Blocks.Interfaces.RealOutput TTop(
+      final quantity="ThermodynamicTemperature",
+      final unit = "K",
+      min=0,
+      displayUnit = "degC")
+    "Temperature at the top"
     annotation (Placement(transformation(
         origin={-77,81},
         extent={{-5,5},{5,-5}},
@@ -90,7 +95,12 @@ model BufferStorage
         extent={{-5,5},{5,-5}},
         rotation=0,
         origin={-80,88})));
-  Modelica.Blocks.Interfaces.RealOutput TBottom "Temperature at the Bottom"
+  Modelica.Blocks.Interfaces.RealOutput TBottom(
+      final quantity="ThermodynamicTemperature",
+      final unit = "K",
+      min=0,
+      displayUnit = "degC")
+    "Temperature at the Bottom"
     annotation (Placement(transformation(
         origin={-77,-77},
         extent={{-5,5},{5,-5}},

--- a/AixLib/Fluid/Storage/BufferStorage.mo
+++ b/AixLib/Fluid/Storage/BufferStorage.mo
@@ -1,4 +1,4 @@
-within AixLib.Fluid.Storage;
+﻿within AixLib.Fluid.Storage;
 model BufferStorage
   "Buffer Storage Model with support for heating rod and two heating coils"
   import SI = Modelica.SIunits;
@@ -55,12 +55,12 @@ model BufferStorage
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 ////////////final parameters////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////////////////////////
- final parameter Integer nHC1Up=integer(AixLib.Utilities.Math.Functions.round(data.hHC1Up/(data.hTank/n) + 0.5,0));
- final parameter Integer nHC1Low=integer(AixLib.Utilities.Math.Functions.round(data.hHC1Low/(data.hTank/n) + 0.5,0));
+ final parameter Integer nHC1Up=integer(ceil(data.hHC1Up/(data.hTank/n)));
+ final parameter Integer nHC1Low=integer(floor(data.hHC1Low/(data.hTank/n))+1);
  final parameter Integer disHC1 = nHC1Up-nHC1Low+1;
 
- final parameter Integer nHC2Up=integer(AixLib.Utilities.Math.Functions.round(data.hHC2Up/(data.hTank/n) + 0.5,0));
- final parameter Integer nHC2Low=integer(AixLib.Utilities.Math.Functions.round(data.hHC2Low/(data.hTank/n) + 0.5,0));
+ final parameter Integer nHC2Up=integer(ceil(data.hHC2Up/(data.hTank/n)));
+ final parameter Integer nHC2Low=integer(floor(data.hHC2Low/(data.hTank/n))+1);
  final parameter Integer disHC2 = nHC2Up-nHC2Low+1;
 
  final parameter Integer nHR=integer(AixLib.Utilities.Math.Functions.round(data.hHR/(data.hTank/n) + 0.5,0));
@@ -264,6 +264,24 @@ model BufferStorage
         extent={{-10,-10},{10,10}},
         rotation=270,
         origin={-56,-39})));
+
+initial equation
+   assert(data.hHC1Up<=data.hTank and data.hHC1Up>=0.0 and
+     data.hHC1Low<=data.hTank and data.hHC1Low>=0.0,
+     "Storage coil 1 inlet and outlet must be within tank's height.",
+     level = AssertionLevel.error);
+   assert(data.hHC1Up>data.hHC1Low,
+     "Storage coil 1 upper port must be higher than lower port.",
+     level = AssertionLevel.error);
+
+   assert(data.hHC2Up<=data.hTank and data.hHC2Up>=0.0 and
+     data.hHC2Low<=data.hTank and data.hHC2Low>=0.0,
+     "Storage coil 2 inlet and outlet must be within tank's height.",
+     level = AssertionLevel.error);
+   assert(data.hHC2Up>data.hHC2Low,
+     "Storage coil 2 upper port must be higher than lower port.",
+     level = AssertionLevel.error);
+
 equation
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 ///////////////////connection of Heating Coils//////////////////////////////////////////////////////


### PR DESCRIPTION
See #555. 

Check with the following script critical storage data settings (assuming a tank of 3 m height and a discretisation of 6 layers):

```Modelica
hLowerPort={0.499,0.501,0.0,1.0};
hUpperPort={2.5001,2.499,3.0,2.0};

for i in 1:size(hLowerPort,1) loop
  hTank = 3;
  n = 6;
  n_LP = integer(floor(hLowerPort[i]/(hTank/n))+1);
  n_UP = integer(ceil(hUpperPort[i]/(hTank/n)));
  "hLowerPort = "+String(hLowerPort[i])+" and hUpperPort = "+String(hUpperPort[i]);
  "n_LP = "+String(n_LP);
  "n_UP = "+String(n_UP);
end for;
```

I also introduced assert statements in the initial equation section.
