### PR TITLE
Fix documentation and add Aachen example

### DIFF
--- a/AixLib/BoundaryConditions/GroundTemperature/Examples/ExampleAachen.mo
+++ b/AixLib/BoundaryConditions/GroundTemperature/Examples/ExampleAachen.mo
@@ -25,7 +25,7 @@ equation
 for Energy Efficient Buildings and Indoor Climate at RWTH Aachen University's
 E.ON Energy Research Center (Mathieustr. 10, 52074 Aachen).</p>
 
-<p>The values are derived from TRY wheather data. With free
+<p>The values are derived from TRY weather data. With free
 registration, the 
 <a href=\"http://www.bbsr.bund.de\">Federal Institute for Research on Building, Urban Affairs and Spatial Development</a>
 and the German weather service <a href=\"https://www.dwd.de/EN/Home/home_node.html\">Deutscher Wetterdienst</a>

--- a/AixLib/BoundaryConditions/GroundTemperature/Examples/ExampleAachen.mo
+++ b/AixLib/BoundaryConditions/GroundTemperature/Examples/ExampleAachen.mo
@@ -1,0 +1,46 @@
+within AixLib.BoundaryConditions.GroundTemperature.Examples;
+model ExampleAachen "Ground temperature at the site of EBC"
+  extends Modelica.Icons.Example;
+  GroundTemperatureKusuda groundTemperatureAachen(
+    alpha=0.039,
+    D=1,
+    T_amp=19.25,
+    t_shift=3,
+    T_mean=283.6)
+    "Undisturbed ground temperature model with values for EBC main building"
+    annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
+  Modelica.Thermal.HeatTransfer.Sensors.TemperatureSensor temperatureSensor
+    "Sensor to show ground temperature"
+    annotation (Placement(transformation(extent={{24,-10},{44,10}})));
+  Modelica.Blocks.Interfaces.RealOutput T_ground
+    "Output to show ground temperature"
+    annotation (Placement(transformation(extent={{96,-10},{116,10}})));
+equation
+  connect(groundTemperatureAachen.port_a, temperatureSensor.port) annotation (
+      Line(points={{9.4,-5},{16.7,-5},{16.7,0},{24,0}}, color={191,0,0}));
+  connect(temperatureSensor.T, T_ground)
+    annotation (Line(points={{44,0},{106,0}}, color={0,0,127}));
+  annotation (experiment(StopTime=31536000, Interval=3600), Documentation(info="<html>
+<p>This example shows the ground temperature at the site of the Institute 
+for Energy Efficient Buildings and Indoor Climate at RWTH Aachen University's
+E.ON Energy Research Center (Mathieustr. 10, 52074 Aachen).</p>
+
+<p>The values are derived from TRY wheather data. With free
+registration, the 
+<a href=\"http://www.bbsr.bund.de\">Federal Institute for Research on Building, Urban Affairs and Spatial Development</a>
+and the German weather service <a href=\"https://www.dwd.de/EN/Home/home_node.html\">Deutscher Wetterdienst</a>
+provide local test reference year weather files at
+<a href=\"https://kunden.dwd.de/obt/\">https://kunden.dwd.de/obt/</a>.</p>
+
+<p>The values used in this example were derived from a TRY file using the Python code
+available at <a href=\"https://gist.github.com/marcusfuchs/04977d439077016a1acdca03285ef15e\">this Gist</a>.</p> 
+
+</html>", revisions="<html>
+<ul>
+<li>
+  April 30, 2018, by Marcus Fuchs:<br/>
+  First implementation as part of <a href=\"https://github.com/RWTH-EBC/AixLib/issues/561\">issue 561</a>.
+</li>
+</ul>
+</html>"));
+end ExampleAachen;

--- a/AixLib/BoundaryConditions/GroundTemperature/Examples/ExampleSanFran.mo
+++ b/AixLib/BoundaryConditions/GroundTemperature/Examples/ExampleSanFran.mo
@@ -10,7 +10,7 @@ model ExampleSanFran
         transformation(extent={{-90,54},{-50,94}}), iconTransformation(extent={{
             -168,6},{-148,26}})));
   Modelica.Blocks.Interfaces.RealOutput T_air "Output to show air temperature"
-    annotation (Placement(transformation(extent={{140,62},{160,82}})));
+    annotation (Placement(transformation(extent={{98,62},{118,82}})));
   Modelica.Blocks.Continuous.Integrator integrator "Integrates air temperature
   to compute average air temperature"
     annotation (Placement(transformation(extent={{0,40},{20,60}})));
@@ -21,7 +21,7 @@ model ExampleSanFran
     annotation (Placement(transformation(extent={{-40,-18},{-20,2}})));
   Modelica.Blocks.Interfaces.RealOutput T_mean "Output of average air
   temperature since beginning of simulation"
-    annotation (Placement(transformation(extent={{140,20},{160,40}})));
+    annotation (Placement(transformation(extent={{98,20},{118,40}})));
   Modelica.Blocks.Math.Max denominatorTmean
     "Max-function to prevent division by 0 at time=0"
     annotation (Placement(transformation(extent={{10,-12},{30,8}})));
@@ -41,30 +41,30 @@ model ExampleSanFran
     annotation (Placement(transformation(extent={{40,-60},{60,-40}})));
   Modelica.Blocks.Interfaces.RealOutput T_ground "Output to show ground
   temperature"
-    annotation (Placement(transformation(extent={{140,-56},{160,-36}})));
+    annotation (Placement(transformation(extent={{98,-60},{118,-40}})));
   Modelica.Thermal.HeatTransfer.Sensors.TemperatureSensor temperatureSensor
     "Sensor to show ground temperature"
     annotation (Placement(transformation(extent={{74,-60},{94,-40}})));
   Modelica.Blocks.Interfaces.RealOutput T_amp
     "Keeps track of the amplitude of the air temperature"
-    annotation (Placement(transformation(extent={{140,-10},{160,10}})));
+    annotation (Placement(transformation(extent={{98,-10},{118,10}})));
 equation
 
  T_max=max(T_max, T_air);
  T_min=min(T_min, T_air);
  T_amp = (T_max-T_min)/2;
-  connect(T_air, weaBus.TDryBul) annotation (Line(points={{150,72},{-70,72},{-70,
-          74}}, color={0,0,127}), Text(
+  connect(T_air, weaBus.TDryBul) annotation (Line(points={{108,72},{-70,72},{
+          -70,74}},
+                color={0,0,127}), Text(
       string="%second",
       index=1,
       extent={{6,3},{6,3}}));
   connect(integrator.u, T_air) annotation (Line(points={{-2,50},{-14,50},{-14,
-          72},{150,72}}, color={0,0,127}));
+          72},{108,72}}, color={0,0,127}));
   connect(integrator.y, division.u1) annotation (Line(points={{21,50},{30,50},{30,
           36},{38,36}}, color={0,0,127}));
   connect(division.y, T_mean)
-    annotation (Line(points={{61,30},{92,30},{150,30}},
-                                                color={0,0,127}));
+    annotation (Line(points={{61,30},{108,30}}, color={0,0,127}));
   connect(division.u2, denominatorTmean.y)
     annotation (Line(points={{38,24},{31,24},{31,-2}}, color={0,0,127}));
   connect(denominatorTmean.u2, timeSource.y)
@@ -80,8 +80,10 @@ equation
       extent={{6,3},{6,3}}));
   connect(groundTemperatureKusuda.port_a, temperatureSensor.port) annotation (
       Line(points={{59.4,-55},{70,-55},{70,-50},{74,-50}}, color={191,0,0}));
-  connect(temperatureSensor.T, T_ground) annotation (Line(points={{94,-50},{110,
-          -50},{110,-46},{150,-46}}, color={0,0,127}));
+  connect(temperatureSensor.T, T_ground) annotation (Line(points={{94,-50},{108,
+          -50}},                     color={0,0,127}));
+  connect(T_mean, T_mean)
+    annotation (Line(points={{108,30},{108,30}}, color={0,0,127}));
   annotation (Documentation(revisions="<html>
 <ul>
 <li><i>May 2017</i>, by Felix Buenning: Updated documentation, added T_amp as output</li>

--- a/AixLib/BoundaryConditions/GroundTemperature/Examples/ExampleSanFran.mo
+++ b/AixLib/BoundaryConditions/GroundTemperature/Examples/ExampleSanFran.mo
@@ -32,18 +32,18 @@ model ExampleSanFran
       computeWetBulbTemperature=false, filNam=Modelica.Utilities.Files.loadResource("modelica://AixLib/Resources/weatherdata/USA_CA_San.Francisco.Intl.AP.724940_TMY3.mos"))
                                        "File reader that reads weather data"
     annotation (Placement(transformation(extent={{-40,78},{-20,98}})));
-  GroundTemperatureKusuda groundTemperatureKasuda(
+  GroundTemperatureKusuda groundTemperatureKusuda(
     t_shift=23,
     alpha=0.039,
     D=1,
-    T_mean=286.95,
-    T_amp=15.49)   "Undisturbed ground temperature model"
+    T_amp=15.49,
+    T_mean=286.95) "Undisturbed ground temperature model"
     annotation (Placement(transformation(extent={{40,-60},{60,-40}})));
   Modelica.Blocks.Interfaces.RealOutput T_ground "Output to show ground
   temperature"
     annotation (Placement(transformation(extent={{140,-56},{160,-36}})));
-  Modelica.Thermal.HeatTransfer.Sensors.TemperatureSensor temperatureSensor "Sensor
-  to show ground temperature"
+  Modelica.Thermal.HeatTransfer.Sensors.TemperatureSensor temperatureSensor
+    "Sensor to show ground temperature"
     annotation (Placement(transformation(extent={{74,-60},{94,-40}})));
   Modelica.Blocks.Interfaces.RealOutput T_amp
     "Keeps track of the amplitude of the air temperature"
@@ -78,7 +78,7 @@ equation
       string="%second",
       index=1,
       extent={{6,3},{6,3}}));
-  connect(groundTemperatureKasuda.port_a, temperatureSensor.port) annotation (
+  connect(groundTemperatureKusuda.port_a, temperatureSensor.port) annotation (
       Line(points={{59.4,-55},{70,-55},{70,-50},{74,-50}}, color={191,0,0}));
   connect(temperatureSensor.T, T_ground) annotation (Line(points={{94,-50},{110,
           -50},{110,-46},{150,-46}}, color={0,0,127}));

--- a/AixLib/BoundaryConditions/GroundTemperature/Examples/package.order
+++ b/AixLib/BoundaryConditions/GroundTemperature/Examples/package.order
@@ -1,1 +1,2 @@
 ExampleSanFran
+ExampleAachen

--- a/AixLib/BoundaryConditions/GroundTemperature/GroundTemperatureKusuda.mo
+++ b/AixLib/BoundaryConditions/GroundTemperature/GroundTemperatureKusuda.mo
@@ -2,7 +2,8 @@ within AixLib.BoundaryConditions.GroundTemperature;
 model GroundTemperatureKusuda "Model for undisturbed ground temperature"
 
   parameter Modelica.SIunits.Temperature T_mean "Average air temperature over the year";
-  parameter Modelica.SIunits.TemperatureDifference T_amp "Difference between max and min air temperature";
+  parameter Modelica.SIunits.TemperatureDifference T_amp
+    "Amplitude of surface temperature [(maximum air temperature - minimum air temperature)/2]";
   parameter Modelica.SIunits.Distance D "Depth of ground temperature";
   parameter Modelica.SIunits.ThermalDiffusivity alpha=0.04 "Thermal diffusivity of the ground. Declare in m2/day!";
   parameter Modelica.SIunits.Time t_shift "Time of the year with minimum air temperature. Declare in days!";
@@ -51,6 +52,10 @@ equation
         coordinateSystem(preserveAspectRatio=false)),
     Documentation(revisions="<html>
 <ul>
+<li>
+  April 30, 2018, by Marcus Fuchs:<br/>
+  Update documentation (see <a href=\"https://github.com/RWTH-EBC/AixLib/issues/561\">issue 561</a>).
+  </li>
 <li><i>May 2017</i>, by Felix Buenning: Updated information window according to documentation standards</li>
 <li><i>October 2016</i>, by Felix Buenning: Developed and implemented</li>
 </ul>
@@ -86,7 +91,11 @@ does not support m2/day as a display unit.)</b></p>
 
 <p> The validation was done by comparing simulation results 
 (<a href=\"AixLib.BoundaryConditions.GroundTemperature.Examples.ExampleSanFran\">San Francisco example</a>) with the 
-findings of the first given reference below (Florides and Kalogirou,2005). </p> 
+findings of the first given reference below (Florides and Kalogirou,2005). </p>
+<p>The
+<a href=\"https://www.pik-potsdam.de/services/climate-weather-potsdam/climate-diagrams/ground-temperature\">Potsdam Institute for Climate Impact Research</a>
+provides measurement data for a German site, which can be used for comparison.</p>
+
 
 <h4>Implementation</h4> 
 <p>The model implements the equation given above and supplies the undisturbed ground temperature via


### PR DESCRIPTION
This closes #561. The main changes are:

- Fix misleading documentation in the ground temperature model
- Fix typos and whitespaces
- Add a new example with ground temperature at the site of our main building in Aachen
