### PR TITLE
#564 change package order of AixLib.FastHVAC.Components

### DIFF
--- a/AixLib/FastHVAC/Components/package.order
+++ b/AixLib/FastHVAC/Components/package.order
@@ -1,9 +1,9 @@
 Controller
+HeatExchangers
+HeatGenerators
 Pipes
 Pumps
-HeatGenerators
-HeatExchangers
 Sensors
-Valves
 Sinks
 Storage
+Valves


### PR DESCRIPTION
This pull request refers to #564 and changes the package order of AixLib.FastHVAC.Components