### PR TITLE
Issue651 Revisions in WindowModels

### DIFF
--- a/AixLib/ThermalZones/HighOrder/Components/Walls/Wall_ASHRAE140.mo
+++ b/AixLib/ThermalZones/HighOrder/Components/Walls/Wall_ASHRAE140.mo
@@ -1,4 +1,4 @@
-﻿within AixLib.ThermalZones.HighOrder.Components.Walls;
+within AixLib.ThermalZones.HighOrder.Components.Walls;
 model Wall_ASHRAE140
   "Wall modell for ASHRAE 140 with absorbtion of solar radiation"
 
@@ -133,8 +133,7 @@ public
                                                 windowSimple(
     T0=T0,
     windowarea=windowarea,
-    WindowType=WindowType,
-    eps_out=0.84) if          withWindow and outside
+    WindowType=WindowType) if          withWindow and outside
     annotation (Placement(transformation(extent={{-15,-48},{11,-22}})));
   Utilities.HeatTransfer.HeatConv_outside
                                         heatTransfer_Outside(

--- a/AixLib/ThermalZones/HighOrder/Components/WindowsDoors/WindowSimple.mo
+++ b/AixLib/ThermalZones/HighOrder/Components/WindowsDoors/WindowSimple.mo
@@ -1,6 +1,5 @@
-within AixLib.ThermalZones.HighOrder.Components.WindowsDoors;
+﻿within AixLib.ThermalZones.HighOrder.Components.WindowsDoors;
 model WindowSimple "Window with radiation and U-Value"
-  //  parameter Modelica.SIunits.Area windowarea=2 "Total fenestration area";
   parameter Modelica.SIunits.Area windowarea=2 "Total fenestration area";
   parameter Modelica.SIunits.Temperature T0=293.15 "Initial temperature";
   parameter Boolean selectable=true "Select window type"
@@ -37,12 +36,6 @@ model WindowSimple "Window with radiation and U-Value"
     final Uw=Uw,
     final n=1)
     annotation (Placement(transformation(extent={{-50,50},{-30,70}})));
-  Utilities.HeatTransfer.HeatToStar twoStar_RadEx(
-    Therm(T(start=T0)),
-    Star(T(start=T0)),
-    final A=(1 - frameFraction)*windowarea,
-    final eps=WindowType.Emissivity)
-    annotation (Placement(transformation(extent={{30,50},{50,70}})));
   Utilities.Interfaces.Star Star
     annotation (Placement(transformation(extent={{80,50},{100,70}})));
   Modelica.Thermal.HeatTransfer.Interfaces.HeatPort_a port_outside
@@ -58,8 +51,6 @@ model WindowSimple "Window with radiation and U-Value"
   Modelica.Thermal.HeatTransfer.Sources.PrescribedHeatFlow prescribedHeatFlow
     annotation (Placement(transformation(extent={{2,50},{22,70}})));
 equation
-  connect(twoStar_RadEx.Star, Star)
-    annotation (Line(points={{49.1,60},{90,60}}, pattern=LinePattern.Solid));
   connect(port_outside, HeatTrans.port_a)
     annotation (Line(points={{-90,-10},{-49.5,-10},{-10,-10}}));
   connect(HeatTrans.port_b, port_inside)
@@ -71,8 +62,8 @@ equation
     annotation (Line(points={{-31,60},{-17.2,60}}, color={0,0,127}));
   connect(Ag.y, prescribedHeatFlow.Q_flow)
     annotation (Line(points={{-3.4,60},{2,60}}, color={0,0,127}));
-  connect(prescribedHeatFlow.port, twoStar_RadEx.Therm)
-    annotation (Line(points={{22,60},{30.8,60}}, color={191,0,0}));
+  connect(Star, prescribedHeatFlow.port)
+    annotation (Line(points={{90,60},{22,60}}, color={95,95,95}));
   annotation (
     Icon(coordinateSystem(
         preserveAspectRatio=false,
@@ -146,6 +137,8 @@ equation
  <p><a href=\"AixLib.Building.Components.Examples.WindowsDoors.WindowSimple\">AixLib.Building.Components.Examples.WindowsDoors.WindowSimple</a></p>
  </html>", revisions="<html>
  <ul>
+ <li><i>November 2, 2018Mai 19, 2014&nbsp;</i> by Fabian Wüllhorst:<br/>Remove redundand twoStar_radEx from model. 
+This is for <a href=\"https://github.com/RWTH-EBC/AixLib/issues/651\">#651</a>.</li>
  <li><i>Mai 19, 2014&nbsp;</i> by Ana Constantin:<br/>Uses components from MSL and respects the naming conventions</li>
  <li><i>May 02, 2013&nbsp;</i> by Ole Odendahl:<br/>Formatted documentation appropriately</li>
  <li><i>March 30, 2012&nbsp;</i> by Ana Constantin and Corinna Leonhardt:<br/>Implemented.</li>

--- a/AixLib/ThermalZones/HighOrder/Components/WindowsDoors/Window_ASHRAE140.mo
+++ b/AixLib/ThermalZones/HighOrder/Components/WindowsDoors/Window_ASHRAE140.mo
@@ -1,4 +1,4 @@
-within AixLib.ThermalZones.HighOrder.Components.WindowsDoors;
+﻿within AixLib.ThermalZones.HighOrder.Components.WindowsDoors;
 model Window_ASHRAE140
   "Window with transmission correction factor, modelling of window panes"
   extends
@@ -21,10 +21,6 @@ model Window_ASHRAE140
 
   parameter Real g= if selectable then WindowType.g else 0.60
     "Coefficient of solar energy transmission"                                                            annotation (Dialog(group="Window type", enable = not selectable));
-  parameter Real eps_out=0.9 "emissivity of the outer surface"
-                                       annotation(Dialog(group = "Outside surface", enable = outside));
-                                       parameter Real phi= 90
-    "surface tilted angle in [degree]"                                                           annotation(Dialog(group = "Outside surface", enable = outside));
 
   BaseClasses.CorrectionSolarGain.CorG_VDI6007
     RadCondAdapt(Uw=Uw) annotation (Placement(transformation(extent={{-52,48},{
@@ -195,6 +191,7 @@ equation
 </html>",
  revisions="<html>
  <ul>
+ <li><i>November 11, 2018&nbsp;</i> by Fabian Wüllhorst: Removed parameters phi and eps_out(see issue651 on this)<br/></li>
  <li><i>March 30, 2015&nbsp;</i> by Ana Constantin:Improved implementation of transmitted solar radiation<br/></li>
  <li><i>February 24, 2014&nbsp;</i> by Reza Tavakoli:<br/>First implementation</li>
 </ul>

--- a/AixLib/ThermalZones/HighOrder/Components/WindowsDoors/Window_ASHRAE140.mo
+++ b/AixLib/ThermalZones/HighOrder/Components/WindowsDoors/Window_ASHRAE140.mo
@@ -191,8 +191,8 @@ equation
 </html>",
  revisions="<html>
  <ul>
- <li><i>November 11, 2018&nbsp;</i> by Fabian Wüllhorst: Removed parameters phi and eps_out(see issue651 on this)<br/></li>
- <li><i>March 30, 2015&nbsp;</i> by Ana Constantin:Improved implementation of transmitted solar radiation<br/></li>
+ <li><i>November 11, 2018&nbsp;</i> by Fabian Wüllhorst: <br/>Removed parameters phi and eps_out. This is for <a href=\"https://github.com/RWTH-EBC/AixLib/issues/651\">#651</a>.</li>
+ <li><i>March 30, 2015&nbsp;</i> by Ana Constantin:<br/>Improved implementation of transmitted solar radiation</li>
  <li><i>February 24, 2014&nbsp;</i> by Reza Tavakoli:<br/>First implementation</li>
 </ul>
 </html>"),


### PR DESCRIPTION
As mentioned in #651, the model `twoStar_radEx` has no impact on the model `WindowSimple`. Furthermore the parameters `phi` and `eps_out` are not being used. Therefore the parameters and the model are removed.
The revisions link to the issue to understand why the changes where made.