### PR TITLE
Issue690 multizone internal gains

### DIFF
--- a/AixLib/DataBase/ThermalZones/OfficePassiveHouse/OPH_1_Office.mo
+++ b/AixLib/DataBase/ThermalZones/OfficePassiveHouse/OPH_1_Office.mo
@@ -54,11 +54,11 @@ record OPH_1_Office "Office zone of office building"
     wfWall = {0.2, 0.2, 0.2, 0.2, 0.1},
     wfWin = {0.25, 0.25, 0.25, 0.25, 0},
     wfGro = 0.1,
-    nrPeople = 83.75,
+    internalGainsPeopleSpecific = 3.5,
     ratioConvectiveHeatPeople = 0.5,
-    nrPeopleMachines = 117.25,
+    internalGainsMachinesSpecific = 7.0,
     ratioConvectiveHeatMachines = 0.6,
-    lightingPower = 12.5,
+    lightingPowerSpecific = 12.5,
     ratioConvectiveHeatLighting = 0.6,
     useConstantACHrate = false,
     baseACH = 0.2,
@@ -81,6 +81,10 @@ record OPH_1_Office "Office zone of office building"
     CoolerOn = false);
   annotation (Documentation(revisions="<html>
  <ul>
+  <li>
+  February 28, 2019, by Niklas Huelsenbeck:<br/>
+  Adapting nrPeople and nrPeopleMachines to new calculation scheme.
+  </li>
   <li>
   September 27, 2016, by Moritz Lauster:<br/>
   Reimplementation.

--- a/AixLib/DataBase/ThermalZones/OfficePassiveHouse/OPH_1_Office.mo
+++ b/AixLib/DataBase/ThermalZones/OfficePassiveHouse/OPH_1_Office.mo
@@ -82,8 +82,8 @@ record OPH_1_Office "Office zone of office building"
   annotation (Documentation(revisions="<html>
  <ul>
   <li>
-  February 28, 2019, by Niklas Huelsenbeck:<br/>
-  Adapting nrPeople and nrPeopleMachines to new calculation scheme.
+  February 28, 2019, by Niklas Huelsenbeck, dja, mre:<br/>
+  Adapting nrPeople and nrPeopleMachines to area specific approach 
   </li>
   <li>
   September 27, 2016, by Moritz Lauster:<br/>

--- a/AixLib/DataBase/ThermalZones/ZoneBaseRecord.mo
+++ b/AixLib/DataBase/ThermalZones/ZoneBaseRecord.mo
@@ -79,10 +79,10 @@ record ZoneBaseRecord "Base record definition for zone records"
   parameter Real wfGro
     "Weight factor of the ground";
 
-  parameter Real nrPeople "Number of people in the room";
+  parameter Real internalGainsPeopleSpecific "Specific Heat Flow from people to the environment";
   parameter Real ratioConvectiveHeatPeople
     "Ratio of convective heat from overall heat output for people";
-  parameter Real nrPeopleMachines "Number of people with machines";
+  parameter Real internalGainsMachinesSpecific "Specific Heat Flow from machines to the environment";
   parameter Real ratioConvectiveHeatMachines
     "Ratio of convective heat from overall heat output for machines";
   parameter Modelica.SIunits.HeatFlux lightingPower "Heat flux of lighting";

--- a/AixLib/DataBase/ThermalZones/ZoneBaseRecord.mo
+++ b/AixLib/DataBase/ThermalZones/ZoneBaseRecord.mo
@@ -79,13 +79,13 @@ record ZoneBaseRecord "Base record definition for zone records"
   parameter Real wfGro
     "Weight factor of the ground";
 
-  parameter Real internalGainsPeopleSpecific "Specific Heat Flow from people to the environment";
+  parameter Real internalGainsPeopleSpecific "Heat Flux of people";
   parameter Real ratioConvectiveHeatPeople
     "Ratio of convective heat from overall heat output for people";
-  parameter Real internalGainsMachinesSpecific "Specific Heat Flow from machines to the environment";
+  parameter Real internalGainsMachinesSpecific "Heat Flux of machines";
   parameter Real ratioConvectiveHeatMachines
     "Ratio of convective heat from overall heat output for machines";
-  parameter Modelica.SIunits.HeatFlux lightingPower "Heat flux of lighting";
+  parameter Modelica.SIunits.HeatFlux lightingPowerSpecific "Heat flux of lighting";
   parameter Real ratioConvectiveHeatLighting
     "Ratio of convective heat from overall heat output for lights";
   parameter Boolean useConstantACHrate

--- a/AixLib/ThermalZones/ReducedOrder/ThermalZone/ThermalZone.mo
+++ b/AixLib/ThermalZones/ReducedOrder/ThermalZone/ThermalZone.mo
@@ -325,6 +325,10 @@ equation
 </html>",  revisions="<html>
  <ul>
   <li>
+  March 01, 2019, by Niklas Huelsenbeck:<br/>
+  Integration of new Internal Gains models, HumanSensibleHeatAreaSpecific and MachinesAreaSpecific
+  </li>
+  <li>
   September 27, 2016, by Moritz Lauster:<br/>
   Reimplementation based on Annex60 and MSL models.
   </li>

--- a/AixLib/ThermalZones/ReducedOrder/ThermalZone/ThermalZone.mo
+++ b/AixLib/ThermalZones/ReducedOrder/ThermalZone/ThermalZone.mo
@@ -9,23 +9,32 @@ model ThermalZone
     "Model for correction of solar transmission"
     annotation(choicesAllMatching=true);
 
-  replaceable Utilities.Sources.InternalGains.Humans.HumanSensibleHeat_VDI2078
+  replaceable Utilities.Sources.InternalGains.Humans.HumanSensibleHeatAreaSpecific
     humanSenHea(
-    final ActivityType=3,
     final T0=zoneParam.T_start,
-    final NrPeople=zoneParam.nrPeople,
-    final RatioConvectiveHeat=zoneParam.ratioConvectiveHeatPeople) if ATot > 0
+    final RatioConvectiveHeat=zoneParam.ratioConvectiveHeatPeople,
+    final RoomArea=zoneParam.AZone) if ATot > 0
+    constrainedby
+    Utilities.Sources.InternalGains.Humans.HumanSensibleHeat_VDI2078(
+    final T0=zoneParam.T_start,
+    final RatioConvectiveHeat=zoneParam.ratioConvectiveHeatPeople,
+    final RoomArea=zoneParam.AZone)
     "Internal gains from persons" annotation (choicesAllMatching=true,
       Placement(transformation(extent={{64,-36},{84,-16}})));
-  replaceable Utilities.Sources.InternalGains.Machines.Machines_DIN18599
+  replaceable Utilities.Sources.InternalGains.Machines.MachinesAreaSpecific
     machinesSenHea(
     final ratioConv=zoneParam.ratioConvectiveHeatMachines,
     final T0=zoneParam.T_start,
-    final ActivityType=2,
-    final NrPeople=zoneParam.nrPeopleMachines) if ATot > 0
+    final InternalGainsMachinesSpecific=zoneParam.internalGainsMachinesSpecific,
+    final RoomArea=zoneParam.AZone) if ATot > 0 constrainedby
+    Utilities.Sources.InternalGains.Machines.Machines_DIN18599(
+    final ratioConv=zoneParam.ratioConvectiveHeatMachines,
+    final T0=zoneParam.T_start,
+    final InternalGainsMachinesSpecific=zoneParam.internalGainsMachinesSpecific,
+    final RoomArea=zoneParam.AZone)
     "Internal gains from machines"
     annotation (Placement(transformation(extent={{64,-56},{84,-37}})));
-  replaceable Utilities.Sources.InternalGains.Lights.Lights_relative lights(
+  replaceable Utilities.Sources.InternalGains.Lights.LightsAreaSpecific lights(
     final ratioConv=zoneParam.ratioConvectiveHeatLighting,
     final T0=zoneParam.T_start,
     final LightingPower=zoneParam.lightingPower,
@@ -186,8 +195,6 @@ equation
   connect(machinesSenHea.ConvHeat, ROM.intGainsConv) annotation (Line(points={{83,
           -40.8},{92,-40.8},{92,-40},{92,-40},{92,50},{86,50},{86,50}},
                                                  color={191,0,0}));
-  connect(humanSenHea.TRoom, ROM.intGainsConv) annotation (Line(points={{65,-17},
-          {65,-14},{92,-14},{92,50},{86,50},{86,50}},           color={191,0,0}));
   connect(humanSenHea.RadHeat, ROM.intGainsRad) annotation (Line(points={{83,-27},
           {94,-27},{94,54},{86,54}},   color={95,95,95}));
   connect(machinesSenHea.RadHeat, ROM.intGainsRad) annotation (Line(points={{83,

--- a/AixLib/ThermalZones/ReducedOrder/ThermalZone/ThermalZone.mo
+++ b/AixLib/ThermalZones/ReducedOrder/ThermalZone/ThermalZone.mo
@@ -14,11 +14,6 @@ model ThermalZone
     final T0=zoneParam.T_start,
     final RatioConvectiveHeat=zoneParam.ratioConvectiveHeatPeople,
     final RoomArea=zoneParam.AZone) if ATot > 0
-    constrainedby
-    Utilities.Sources.InternalGains.Humans.HumanSensibleHeat_VDI2078(
-    final T0=zoneParam.T_start,
-    final RatioConvectiveHeat=zoneParam.ratioConvectiveHeatPeople,
-    final RoomArea=zoneParam.AZone)
     "Internal gains from persons" annotation (choicesAllMatching=true,
       Placement(transformation(extent={{64,-36},{84,-16}})));
   replaceable Utilities.Sources.InternalGains.Machines.MachinesAreaSpecific
@@ -26,18 +21,13 @@ model ThermalZone
     final ratioConv=zoneParam.ratioConvectiveHeatMachines,
     final T0=zoneParam.T_start,
     final InternalGainsMachinesSpecific=zoneParam.internalGainsMachinesSpecific,
-    final RoomArea=zoneParam.AZone) if ATot > 0 constrainedby
-    Utilities.Sources.InternalGains.Machines.Machines_DIN18599(
-    final ratioConv=zoneParam.ratioConvectiveHeatMachines,
-    final T0=zoneParam.T_start,
-    final InternalGainsMachinesSpecific=zoneParam.internalGainsMachinesSpecific,
-    final RoomArea=zoneParam.AZone)
+    final RoomArea=zoneParam.AZone) if ATot > 0
     "Internal gains from machines"
     annotation (Placement(transformation(extent={{64,-56},{84,-37}})));
   replaceable Utilities.Sources.InternalGains.Lights.LightsAreaSpecific lights(
     final ratioConv=zoneParam.ratioConvectiveHeatLighting,
     final T0=zoneParam.T_start,
-    final LightingPower=zoneParam.lightingPower,
+    final LightingPower=zoneParam.lightingPowerSpecific,
     final RoomArea=zoneParam.AZone) if ATot > 0 "Internal gains from light"
     annotation (Placement(transformation(extent={{64,-76},{84,-57}})));
   corG corGMod(

--- a/AixLib/ThermalZones/ReducedOrder/ThermalZone/ThermalZoneEquipped.mo
+++ b/AixLib/ThermalZones/ReducedOrder/ThermalZone/ThermalZoneEquipped.mo
@@ -41,7 +41,7 @@ model ThermalZoneEquipped
   redeclare Utilities.Sources.InternalGains.Lights.LightsAreaSpecific lights(
     final ratioConv=zoneParam.ratioConvectiveHeatLighting,
     final T0=zoneParam.T_start,
-    final LightingPower=zoneParam.lightingPower,
+    final LightingPower=zoneParam.lightingPowerSpecific,
     final RoomArea=zoneParam.AZone) if ATot > 0 "Internal gains from light"
     annotation (Placement(transformation(extent={{64,-76},{84,-57}})));
 

--- a/AixLib/ThermalZones/ReducedOrder/ThermalZone/ThermalZoneEquipped.mo
+++ b/AixLib/ThermalZones/ReducedOrder/ThermalZone/ThermalZoneEquipped.mo
@@ -21,24 +21,24 @@ model ThermalZoneEquipped
     ATot > 0 or zoneParam.VAir > 0 "Heat flow due to ventilation"
     annotation (Placement(transformation(extent={{-22,-26},{-6,-10}})));
 
-  redeclare Utilities.Sources.InternalGains.Humans.HumanSensibleHeat_VDI2078
+  redeclare Utilities.Sources.InternalGains.Humans.HumanSensibleHeatAreaSpecific
     humanSenHea(
-    final ActivityType=3,
     final T0=zoneParam.T_start,
-    final NrPeople=zoneParam.nrPeople,
-    final RatioConvectiveHeat=zoneParam.ratioConvectiveHeatPeople) if ATot > 0
+    final InternalGainsPeopleSpecific=zoneParam.internalGainsPeopleSpecific,
+    final RatioConvectiveHeat=zoneParam.ratioConvectiveHeatPeople,
+    final RoomArea=zoneParam.AZone) if ATot > 0
     "Internal gains from persons" annotation (choicesAllMatching=true,
       Placement(transformation(extent={{64,-36},{84,-16}})));
 
-  redeclare Utilities.Sources.InternalGains.Machines.Machines_DIN18599
+  redeclare Utilities.Sources.InternalGains.Machines.MachinesAreaSpecific
     machinesSenHea(
     final ratioConv=zoneParam.ratioConvectiveHeatMachines,
     final T0=zoneParam.T_start,
-    final ActivityType=2,
-    final NrPeople=zoneParam.nrPeopleMachines) if ATot > 0
+    final InternalGainsMachinesSpecific=zoneParam.internalGainsMachinesSpecific,
+    final RoomArea=zoneParam.AZone) if ATot > 0
     "Internal gains from machines"
     annotation (Placement(transformation(extent={{64,-56},{84,-37}})));
-  redeclare Utilities.Sources.InternalGains.Lights.Lights_relative lights(
+  redeclare Utilities.Sources.InternalGains.Lights.LightsAreaSpecific lights(
     final ratioConv=zoneParam.ratioConvectiveHeatLighting,
     final T0=zoneParam.T_start,
     final LightingPower=zoneParam.lightingPower,

--- a/AixLib/ThermalZones/ReducedOrder/ThermalZone/ThermalZoneEquipped.mo
+++ b/AixLib/ThermalZones/ReducedOrder/ThermalZone/ThermalZoneEquipped.mo
@@ -119,6 +119,10 @@ equation
 </html>",  revisions="<html>
 <ul>
   <li>
+  March 01, 2019, by Niklas Huelsenbeck:<br/>
+  Changes due to integration of new Internal Gains models in ThermalZone.
+  </li>
+  <li>
   September 27, 2016, by Moritz Lauster:<br/>
   Reimplementation based on Annex60 and MSL models.
   </li>

--- a/AixLib/Utilities/Sources/InternalGains/Examples/InternalGains/Lights.mo
+++ b/AixLib/Utilities/Sources/InternalGains/Examples/InternalGains/Lights.mo
@@ -4,7 +4,7 @@ model Lights "Simulation to check the light models"
   Utilities.Sources.InternalGains.Lights.Lights_simple
     lights_sensibleHeat_simple
     annotation (Placement(transformation(extent={{-10,48},{10,68}})));
-  Utilities.Sources.InternalGains.Lights.Lights_relative lights
+  AixLib.Utilities.Sources.InternalGains.Lights.LightsAreaSpecific lights
     annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
   Utilities.Sources.InternalGains.Lights.Lights_Avar lights_sensibleHeat_Avar
     annotation (Placement(transformation(extent={{-10,-62},{10,-42}})));

--- a/AixLib/Utilities/Sources/InternalGains/Examples/InternalGains/OneOffice.mo
+++ b/AixLib/Utilities/Sources/InternalGains/Examples/InternalGains/OneOffice.mo
@@ -7,7 +7,7 @@ model OneOffice
   Utilities.Sources.InternalGains.Machines.Machines_DIN18599
     machines_SensibleHeat_DIN18599(NrPeople=2)
     annotation (Placement(transformation(extent={{-10,-6},{14,24}})));
-  Utilities.Sources.InternalGains.Lights.Lights_relative lights
+  AixLib.Utilities.Sources.InternalGains.Lights.LightsAreaSpecific lights
     annotation (Placement(transformation(extent={{-8,-46},{12,-22}})));
   Modelica.Thermal.HeatTransfer.Sources.PrescribedTemperature RoomTemp annotation(Placement(transformation(extent = {{-58, 40}, {-38, 60}})));
   Modelica.Blocks.Sources.Ramp Evolution_RoomTemp(duration = 36000, offset = 293.15, startTime = 4000, height = 0) annotation(Placement(transformation(extent = {{-100, 40}, {-80, 60}})));

--- a/AixLib/Utilities/Sources/InternalGains/Humans/HumanSensibleHeatAreaSpecific.mo
+++ b/AixLib/Utilities/Sources/InternalGains/Humans/HumanSensibleHeatAreaSpecific.mo
@@ -1,0 +1,86 @@
+within AixLib.Utilities.Sources.InternalGains.Humans;
+model HumanSensibleHeatAreaSpecific
+  "Model for sensible heat output after VDI 2078"
+  //Internal Gains People
+  parameter Real InternalGainsPeopleSpecific = 1.0 "Specific Heat Flow from people to the environment" annotation(Dialog(descriptionLabel = true));
+  parameter Real RatioConvectiveHeat = 0.5
+    "Ratio of convective heat from overall heat output"                                        annotation(Dialog(descriptionLabel = true));
+  parameter Modelica.SIunits.Area RoomArea=20 "Area of room" annotation(Dialog(descriptionLabel = true));
+  Modelica.Thermal.HeatTransfer.Interfaces.HeatPort_a ConvHeat annotation(Placement(transformation(extent = {{80, 40}, {100, 60}})));
+  Utilities.HeatTransfer.HeatToStar_Avar RadiationConvertor(eps = Emissivity_Human) annotation(Placement(transformation(extent = {{48, -22}, {72, 2}})));
+  Utilities.Interfaces.Star RadHeat annotation(Placement(transformation(extent = {{80, -20}, {100, 0}})));
+  Modelica.Blocks.Interfaces.RealInput Schedule annotation(Placement(transformation(extent = {{-120, -40}, {-80, 0}}), iconTransformation(extent = {{-102, -22}, {-80, 0}})));
+  Modelica.Blocks.Math.Gain internalGainsPeopleSpecific(k=
+        InternalGainsPeopleSpecific)
+    annotation (Placement(transformation(extent={{-70,-26},{-58,-14}})));
+  Modelica.Blocks.Math.Gain SurfaceArea_People(k = SurfaceArea_Human) annotation(Placement(transformation(extent={{16,-54},
+            {28,-42}})));
+  parameter Modelica.SIunits.Temperature T0 = Modelica.SIunits.Conversions.from_degC(22)
+    "Initial temperature";
+  Modelica.Blocks.Nonlinear.Limiter limiter(uMax = 1e+23, uMin=1)      annotation(Placement(transformation(extent={{-18,-58},
+            {2,-38}})));
+  Modelica.Blocks.Math.Gain gain(k = RatioConvectiveHeat) annotation(Placement(transformation(extent = {{6, 28}, {14, 36}})));
+  Modelica.Blocks.Math.Gain gain1(k = 1 - RatioConvectiveHeat) annotation(Placement(transformation(extent = {{6, -12}, {14, -4}})));
+  Modelica.Blocks.Sources.Constant Area(k=RoomArea)
+    annotation (Placement(transformation(extent={{-94,32},{-74,52}})));
+  Modelica.Blocks.Math.MultiProduct productHeatOutput(nu=2)
+    annotation (Placement(transformation(extent={{-40,-6},{-20,14}})));
+protected
+  parameter Modelica.SIunits.Area SurfaceArea_Human = 2;
+  parameter Real Emissivity_Human = 0.98;
+  Modelica.Thermal.HeatTransfer.Sources.PrescribedHeatFlow ConvectiveHeat(T_ref = T0) annotation(Placement(transformation(extent = {{18, 20}, {42, 44}})));
+  Modelica.Thermal.HeatTransfer.Sources.PrescribedHeatFlow RadiativeHeat(T_ref = T0) annotation(Placement(transformation(extent = {{18, -20}, {42, 4}})));
+equation
+  connect(ConvectiveHeat.port, ConvHeat) annotation(Line(points = {{42, 32}, {42, 50}, {90, 50}}, color = {191, 0, 0}, pattern = LinePattern.Solid));
+  connect(RadiativeHeat.port, RadiationConvertor.Therm) annotation(Line(points = {{42, -8}, {44, -8}, {44, -12}, {48, -12}, {48, -10}, {48.96, -10}}, color = {191, 0, 0}, pattern = LinePattern.Solid));
+  connect(RadiationConvertor.Star, RadHeat) annotation(Line(points = {{70.92, -10}, {90, -10}}, color = {95, 95, 95}, pattern = LinePattern.Solid));
+  connect(Schedule, internalGainsPeopleSpecific.u)
+    annotation (Line(points={{-100,-20},{-71.2,-20}}, color={0,0,127}));
+  connect(gain.y, ConvectiveHeat.Q_flow) annotation(Line(points = {{14.4, 32}, {18, 32}}, color = {0, 0, 127}));
+  connect(gain1.y, RadiativeHeat.Q_flow) annotation(Line(points = {{14.4, -8}, {18, -8}}, color = {0, 0, 127}));
+  connect(internalGainsPeopleSpecific.y, limiter.u) annotation (Line(points={{-57.4,
+          -20},{-30,-20},{-30,-48},{-20,-48}}, color={0,0,127}));
+  connect(limiter.y, SurfaceArea_People.u) annotation (Line(
+      points={{3,-48},{14.8,-48}},
+      color={0,0,127}));
+  connect(SurfaceArea_People.y, RadiationConvertor.A) annotation (Line(
+      points={{28.6,-48},{40,-48},{40,20},{60,20},{60,0.8}},
+      color={0,0,127}));
+  connect(internalGainsPeopleSpecific.y, productHeatOutput.u[1]) annotation (
+      Line(points={{-57.4,-20},{-54,-20},{-54,4},{-40,4},{-40,7.5}}, color={0,0,
+          127}));
+  connect(Area.y, productHeatOutput.u[2]) annotation (Line(points={{-73,42},{
+          -54,42},{-54,4},{-40,4},{-40,0.5}}, color={0,0,127}));
+  connect(productHeatOutput.y, gain1.u) annotation (Line(points={{-18.3,4},{-8,
+          4},{-8,-8},{5.2,-8}}, color={0,0,127}));
+  connect(productHeatOutput.y, gain.u) annotation (Line(points={{-18.3,4},{-8,4},
+          {-8,32},{5.2,32}}, color={0,0,127}));
+  annotation(Icon(graphics={  Ellipse(extent = {{-36, 98}, {36, 26}}, lineColor = {255, 213, 170}, fillColor = {255, 213, 170},
+            fillPattern =                                                                                                   FillPattern.Solid), Rectangle(extent = {{-48, 20}, {54, -94}}, fillColor = {255, 0, 0},
+            fillPattern =                                                                                                   FillPattern.Solid, pattern = LinePattern.None), Text(extent = {{-40, -2}, {44, -44}}, lineColor = {255, 255, 255}, fillColor = {255, 0, 0},
+            fillPattern =                                                                                                   FillPattern.Solid, textString = "ERC"), Ellipse(extent = {{-24, 80}, {-14, 70}}, fillColor = {0, 0, 0},
+            fillPattern =                                                                                                   FillPattern.Solid, pattern = LinePattern.None, lineColor = {0, 0, 0}), Ellipse(extent = {{10, 80}, {20, 70}}, fillColor = {0, 0, 0},
+            fillPattern =                                                                                                   FillPattern.Solid, pattern = LinePattern.None, lineColor = {0, 0, 0}), Line(points = {{-18, 54}, {-16, 48}, {-10, 44}, {-4, 42}, {2, 42}, {10, 44}, {16, 48}, {18, 54}}, color = {0, 0, 0}, thickness = 1)}), Documentation(info="<html>
+<p><b><font style=\"color: #008000; \">Overview</font></b> </p>
+<p>Model for heat output of a human according to VDI 2078 (Table A.1). The model only considers the dry heat emission and divides it into convective and radiative heat transmission. </p>
+<p><b><font style=\"color: #008000; \">Concept</font></b> </p>
+<p>It is possible to choose between several types of physical activity. </p>
+<p>The heat output depends on the air temperature in the room where the activity takes place. </p>
+<p>A schedule of the activity is also required as constant presence of people in a room is not realistic. The schedule describes the presence of only one person, and can take values from 0 to 1. </p>
+<p><b><font style=\"color: #008000; \">Assumptions</font></b> </p>
+<p>The surface for radiation exchange is computed from the number of persons in the room, which leads to a surface area of zero, when no one is present. In particular cases this might lead to an error as depending of the rest of the system a division by this surface will be introduced in the system of equations -&gt; division by zero.For this reason a limitiation for the surface has been intoduced: as a minimum the surface area of one human and as a maximum a value of 1e+23 m2 (only needed for a complete parametrization of the model). </p>
+<p><b><font style=\"color: #008000; \">References</font></b> </p>
+<p>VDI 2078: Calculation of cooling load and room temperatures of rooms and buildings (VDI Cooling Load Code of Practice) - March 2012 </p>
+<p><b><font style=\"color: #008000; \">Example Results</font></b> </p>
+<p><a href=\"AixLib.Building.Components.Examples.Sources.InternalGains.Humans\">AixLib.Building.Components.Examples.Sources.InternalGains.Humans</a> </p>
+<p><a href=\"AixLib.Building.Components.Examples.Sources.InternalGains.OneOffice\">AixLib.Building.Components.Examples.Sources.InternalGains.OneOffice</a> </p>
+</html>",  revisions="<html>
+ <ul>
+ <li><i>March 23, 2015&nbsp;</i> by Ana Constantin:<br/>Set minimal surface to surface of one person</li>
+ <li><i>Mai 19, 2014&nbsp;</i> by Ana Constantin:<br/>Uses components from MSL and respects the naming conventions</li>
+ <li><i>April 10, 2014&nbsp;</i> by Ana Constantin:<br/>Added a lower positive limit to the surface area, so it won&apos;t lead to a division by zero</li>
+ <li><i>May 07, 2013&nbsp;</i> by Ole Odendahl:<br/>Formatted documentation appropriately</li>
+ <li><i>August 10, 2011</i> by Ana Constantin:<br/>implemented</li>
+ </ul>
+ </html>"));
+end HumanSensibleHeatAreaSpecific;

--- a/AixLib/Utilities/Sources/InternalGains/Humans/HumanSensibleHeatAreaSpecific.mo
+++ b/AixLib/Utilities/Sources/InternalGains/Humans/HumanSensibleHeatAreaSpecific.mo
@@ -1,11 +1,13 @@
 within AixLib.Utilities.Sources.InternalGains.Humans;
 model HumanSensibleHeatAreaSpecific
-  "Model for sensible heat output after VDI 2078"
+  "Model for sensible heat output area specific"
   //Internal Gains People
-  parameter Real InternalGainsPeopleSpecific = 1.0 "Specific Heat Flow from people to the environment" annotation(Dialog(descriptionLabel = true));
+  parameter Modelica.SIunits.HeatFlux InternalGainsPeopleSpecific = 1.0 "Specific Heat Flow from people to the environment" annotation(Dialog(descriptionLabel = true));
   parameter Real RatioConvectiveHeat = 0.5
     "Ratio of convective heat from overall heat output"                                        annotation(Dialog(descriptionLabel = true));
   parameter Modelica.SIunits.Area RoomArea=20 "Area of room" annotation(Dialog(descriptionLabel = true));
+  parameter Modelica.SIunits.Temperature T0 = Modelica.SIunits.Conversions.from_degC(22)
+    "Initial temperature";
   Modelica.Thermal.HeatTransfer.Interfaces.HeatPort_a ConvHeat annotation(Placement(transformation(extent = {{80, 40}, {100, 60}})));
   Utilities.HeatTransfer.HeatToStar_Avar RadiationConvertor(eps = Emissivity_Human) annotation(Placement(transformation(extent = {{48, -22}, {72, 2}})));
   Utilities.Interfaces.Star RadHeat annotation(Placement(transformation(extent = {{80, -20}, {100, 0}})));
@@ -15,8 +17,6 @@ model HumanSensibleHeatAreaSpecific
     annotation (Placement(transformation(extent={{-70,-26},{-58,-14}})));
   Modelica.Blocks.Math.Gain SurfaceArea_People(k = SurfaceArea_Human) annotation(Placement(transformation(extent={{16,-54},
             {28,-42}})));
-  parameter Modelica.SIunits.Temperature T0 = Modelica.SIunits.Conversions.from_degC(22)
-    "Initial temperature";
   Modelica.Blocks.Nonlinear.Limiter limiter(uMax = 1e+23, uMin=1)      annotation(Placement(transformation(extent={{-18,-58},
             {2,-38}})));
   Modelica.Blocks.Math.Gain gain(k = RatioConvectiveHeat) annotation(Placement(transformation(extent = {{6, 28}, {14, 36}})));
@@ -25,9 +25,13 @@ model HumanSensibleHeatAreaSpecific
     annotation (Placement(transformation(extent={{-94,32},{-74,52}})));
   Modelica.Blocks.Math.MultiProduct productHeatOutput(nu=2)
     annotation (Placement(transformation(extent={{-40,-6},{-20,14}})));
+  Modelica.Blocks.Math.Gain PersonHeat(k=1/HeatPerPerson)
+    "Divides total heat by the Heat Output per Person to get number of persons"
+    annotation (Placement(transformation(extent={{-46,-54},{-34,-42}})));
 protected
   parameter Modelica.SIunits.Area SurfaceArea_Human = 2;
   parameter Real Emissivity_Human = 0.98;
+  parameter Modelica.SIunits.HeatFlowRate HeatPerPerson = 70 "Average Heat Flow per person taken from DIN V 18599-10" annotation(Dialog(descriptionLabel = true));
   Modelica.Thermal.HeatTransfer.Sources.PrescribedHeatFlow ConvectiveHeat(T_ref = T0) annotation(Placement(transformation(extent = {{18, 20}, {42, 44}})));
   Modelica.Thermal.HeatTransfer.Sources.PrescribedHeatFlow RadiativeHeat(T_ref = T0) annotation(Placement(transformation(extent = {{18, -20}, {42, 4}})));
 equation
@@ -38,8 +42,6 @@ equation
     annotation (Line(points={{-100,-20},{-71.2,-20}}, color={0,0,127}));
   connect(gain.y, ConvectiveHeat.Q_flow) annotation(Line(points = {{14.4, 32}, {18, 32}}, color = {0, 0, 127}));
   connect(gain1.y, RadiativeHeat.Q_flow) annotation(Line(points = {{14.4, -8}, {18, -8}}, color = {0, 0, 127}));
-  connect(internalGainsPeopleSpecific.y, limiter.u) annotation (Line(points={{-57.4,
-          -20},{-30,-20},{-30,-48},{-20,-48}}, color={0,0,127}));
   connect(limiter.y, SurfaceArea_People.u) annotation (Line(
       points={{3,-48},{14.8,-48}},
       color={0,0,127}));
@@ -49,12 +51,16 @@ equation
   connect(internalGainsPeopleSpecific.y, productHeatOutput.u[1]) annotation (
       Line(points={{-57.4,-20},{-54,-20},{-54,4},{-40,4},{-40,7.5}}, color={0,0,
           127}));
-  connect(Area.y, productHeatOutput.u[2]) annotation (Line(points={{-73,42},{
-          -54,42},{-54,4},{-40,4},{-40,0.5}}, color={0,0,127}));
   connect(productHeatOutput.y, gain1.u) annotation (Line(points={{-18.3,4},{-8,
           4},{-8,-8},{5.2,-8}}, color={0,0,127}));
   connect(productHeatOutput.y, gain.u) annotation (Line(points={{-18.3,4},{-8,4},
           {-8,32},{5.2,32}}, color={0,0,127}));
+  connect(PersonHeat.y, limiter.u)
+    annotation (Line(points={{-33.4,-48},{-20,-48}}, color={0,0,127}));
+  connect(productHeatOutput.y, PersonHeat.u) annotation (Line(points={{-18.3,4},
+          {-18,4},{-18,-32},{-52,-32},{-52,-48},{-47.2,-48}}, color={0,0,127}));
+  connect(Area.y, productHeatOutput.u[2]) annotation (Line(points={{-73,42},{
+          -54,42},{-54,0.5},{-40,0.5}}, color={0,0,127}));
   annotation(Icon(graphics={  Ellipse(extent = {{-36, 98}, {36, 26}}, lineColor = {255, 213, 170}, fillColor = {255, 213, 170},
             fillPattern =                                                                                                   FillPattern.Solid), Rectangle(extent = {{-48, 20}, {54, -94}}, fillColor = {255, 0, 0},
             fillPattern =                                                                                                   FillPattern.Solid, pattern = LinePattern.None), Text(extent = {{-40, -2}, {44, -44}}, lineColor = {255, 255, 255}, fillColor = {255, 0, 0},

--- a/AixLib/Utilities/Sources/InternalGains/Humans/HumanSensibleHeatAreaSpecific.mo
+++ b/AixLib/Utilities/Sources/InternalGains/Humans/HumanSensibleHeatAreaSpecific.mo
@@ -82,6 +82,7 @@ equation
 <p><a href=\"AixLib.Building.Components.Examples.Sources.InternalGains.OneOffice\">AixLib.Building.Components.Examples.Sources.InternalGains.OneOffice</a> </p>
 </html>",  revisions="<html>
  <ul>
+ <li><i>March 01, 2019&nbsp;</i> by Niklas Huelsenbeck:<br/>Duplicated HumanSensibleHeat_VDI2078 Class and adapted it to a heat flux input value instead of a total number of persons</li>
  <li><i>March 23, 2015&nbsp;</i> by Ana Constantin:<br/>Set minimal surface to surface of one person</li>
  <li><i>Mai 19, 2014&nbsp;</i> by Ana Constantin:<br/>Uses components from MSL and respects the naming conventions</li>
  <li><i>April 10, 2014&nbsp;</i> by Ana Constantin:<br/>Added a lower positive limit to the surface area, so it won&apos;t lead to a division by zero</li>

--- a/AixLib/Utilities/Sources/InternalGains/Humans/package.order
+++ b/AixLib/Utilities/Sources/InternalGains/Humans/package.order
@@ -1,1 +1,2 @@
 HumanSensibleHeat_VDI2078
+HumanSensibleHeatAreaSpecific

--- a/AixLib/Utilities/Sources/InternalGains/Lights/LightsAreaSpecific.mo
+++ b/AixLib/Utilities/Sources/InternalGains/Lights/LightsAreaSpecific.mo
@@ -1,5 +1,5 @@
 within AixLib.Utilities.Sources.InternalGains.Lights;
-model Lights_relative "light heat source model"
+model LightsAreaSpecific "light heat source model"
   extends BaseClasses.PartialInternalGain(ratioConv=0.5, RadiativeHeat(T_ref=T0));
   parameter Modelica.SIunits.Area RoomArea=20 "Area of room"    annotation(Dialog( descriptionLabel = true));
   parameter Real LightingPower = 10 "Heating power of lighting in W/m2" annotation(Dialog( descriptionLabel = true));
@@ -73,4 +73,4 @@ equation
 <p><a href=\"AixLib.Building.Examples.Sources.InternalGains.Lights\">AixLib.Building.Examples.Sources.InternalGains.Lights</a> </p>
 <p><a href=\"AixLib.Building.Examples.Sources.InternalGains.OneOffice\">AixLib.Building.Examples.Sources.InternalGains.OneOffice</a></p>
 </html>"));
-end Lights_relative;
+end LightsAreaSpecific;

--- a/AixLib/Utilities/Sources/InternalGains/Lights/package.order
+++ b/AixLib/Utilities/Sources/InternalGains/Lights/package.order
@@ -1,3 +1,3 @@
 Lights_Avar
-Lights_relative
+LightsAreaSpecific
 Lights_simple

--- a/AixLib/Utilities/Sources/InternalGains/Machines/MachinesAreaSpecific.mo
+++ b/AixLib/Utilities/Sources/InternalGains/Machines/MachinesAreaSpecific.mo
@@ -2,12 +2,13 @@ within AixLib.Utilities.Sources.InternalGains.Machines;
 model MachinesAreaSpecific
   extends BaseClasses.PartialInternalGain(RadiativeHeat(T_ref=T0));
 
-  parameter Real InternalGainsMachinesSpecific=1.0 "Specific Heat Flow from machines to the environment"  annotation(Dialog(descriptionLabel = true));
+  parameter Modelica.SIunits.HeatFlux InternalGainsMachinesSpecific=1.0 "Specific Heat Flow from machines to the environment"  annotation(Dialog(descriptionLabel = true));
   parameter Modelica.SIunits.Area SurfaceArea_Machines=2
     "surface area of radiative heat source";
   parameter Modelica.SIunits.Area RoomArea=20 "Area of room" annotation(Dialog(descriptionLabel = true));
   parameter Real Emissivity_Machines=0.98;
 protected
+  parameter Modelica.SIunits.HeatFlowRate HeatPerMachine = 100 "Average Heat Flow per machine taken from DIN V 18599-10" annotation(Dialog(descriptionLabel = true));
   Modelica.Blocks.Math.MultiProduct productHeatOutput(nu=2)
     annotation (Placement(transformation(extent={{-24,-10},{-4,10}})));
 public
@@ -16,7 +17,7 @@ public
     annotation (Placement(transformation(extent={{-60,-46},{-48,-34}})));
   Utilities.HeatTransfer.HeatToStar
                                   RadiationConvertor(eps=
-        Emissivity_Machines, A=max(1e-4, SurfaceArea_Machines*NrPeople))
+        Emissivity_Machines, A=max(1e-4, SurfaceArea_Machines*InternalGainsMachinesSpecific*(1/HeatPerMachine)*RoomArea)) "Surface Area of a machine multiplied with the number of machines"
     annotation (Placement(transformation(extent={{48,-70},{68,-50}})));
   Modelica.Blocks.Sources.Constant Area(k=RoomArea)
     annotation (Placement(transformation(extent={{-92,38},{-72,58}})));
@@ -39,7 +40,7 @@ equation
   connect(internalGainsMachinesSpecific.y, productHeatOutput.u[1]) annotation (
       Line(points={{-47.4,-40},{-36,-40},{-36,0},{-26,0},{-26,3.5},{-24,3.5}},
         color={0,0,127}));
-  connect(roomArea.y, productHeatOutput.u[2]) annotation (Line(points={{-71,48},
+  connect(Area.y, productHeatOutput.u[2]) annotation (Line(points={{-71,48},
           {-36,48},{-36,0},{-24,0},{-24,-3.5}}, color={0,0,127}));
   annotation (Icon(graphics={
         Text(

--- a/AixLib/Utilities/Sources/InternalGains/Machines/MachinesAreaSpecific.mo
+++ b/AixLib/Utilities/Sources/InternalGains/Machines/MachinesAreaSpecific.mo
@@ -310,6 +310,7 @@ limitation of 1e-4 m2 has been introduced.</p>
 </html>",
     revisions="<html>
 <ul>
+<li><i>March 01, 2019&nbsp;</i> by Niklas Huelsenbeck:<br/>Duplicated Machines_DIN18599 Class and adapted it to a heat flux input value instead of a total number of machines</li>
 <li><i>October 19, 2016&nbsp;</i> by Ana Constantin:<br/>Corrected documentation to refer to machines directly</li>
 <li><i>October 21, 2014&nbsp;</i> by Ana Constantin:<br/>Added a lower positive limit to the surface area, so it will not lead to a division by zero</li>
 <li><i>Mai 19, 2014&nbsp;</i> by Ana Constantin:<br/>Uses components from MSL and respects the naming conventions</li>

--- a/AixLib/Utilities/Sources/InternalGains/Machines/MachinesAreaSpecific.mo
+++ b/AixLib/Utilities/Sources/InternalGains/Machines/MachinesAreaSpecific.mo
@@ -1,0 +1,318 @@
+within AixLib.Utilities.Sources.InternalGains.Machines;
+model MachinesAreaSpecific
+  extends BaseClasses.PartialInternalGain(RadiativeHeat(T_ref=T0));
+
+  parameter Real InternalGainsMachinesSpecific=1.0 "Specific Heat Flow from machines to the environment"  annotation(Dialog(descriptionLabel = true));
+  parameter Modelica.SIunits.Area SurfaceArea_Machines=2
+    "surface area of radiative heat source";
+  parameter Modelica.SIunits.Area RoomArea=20 "Area of room" annotation(Dialog(descriptionLabel = true));
+  parameter Real Emissivity_Machines=0.98;
+protected
+  Modelica.Blocks.Math.MultiProduct productHeatOutput(nu=2)
+    annotation (Placement(transformation(extent={{-24,-10},{-4,10}})));
+public
+  Modelica.Blocks.Math.Gain internalGainsMachinesSpecific(k=
+        InternalGainsMachinesSpecific)
+    annotation (Placement(transformation(extent={{-60,-46},{-48,-34}})));
+  Utilities.HeatTransfer.HeatToStar
+                                  RadiationConvertor(eps=
+        Emissivity_Machines, A=max(1e-4, SurfaceArea_Machines*NrPeople))
+    annotation (Placement(transformation(extent={{48,-70},{68,-50}})));
+  Modelica.Blocks.Sources.Constant Area(k=RoomArea)
+    annotation (Placement(transformation(extent={{-92,38},{-72,58}})));
+equation
+  connect(Schedule, internalGainsMachinesSpecific.u) annotation (Line(points={{-100,
+          0},{-85.6,0},{-85.6,-40},{-61.2,-40}}, color={0,0,127}));
+  connect(RadiationConvertor.Star, RadHeat) annotation (Line(
+      points={{67.1,-60},{90,-60}},
+      color={95,95,95},
+      pattern=LinePattern.Solid));
+  connect(RadiativeHeat.port, RadiationConvertor.Therm) annotation (Line(
+      points={{40,-10},{48,-10},{48,-60},{48.8,-60}},
+      color={191,0,0}));
+  connect(productHeatOutput.y, gain.u) annotation (Line(
+      points={{-2.3,0},{0,0},{0,30},{3.2,30}},
+      color={0,0,127}));
+  connect(productHeatOutput.y, gain1.u) annotation (Line(
+      points={{-2.3,0},{0,0},{0,-10},{3.2,-10}},
+      color={0,0,127}));
+  connect(internalGainsMachinesSpecific.y, productHeatOutput.u[1]) annotation (
+      Line(points={{-47.4,-40},{-36,-40},{-36,0},{-26,0},{-26,3.5},{-24,3.5}},
+        color={0,0,127}));
+  connect(roomArea.y, productHeatOutput.u[2]) annotation (Line(points={{-71,48},
+          {-36,48},{-36,0},{-24,0},{-24,-3.5}}, color={0,0,127}));
+  annotation (Icon(graphics={
+        Text(
+          extent={{-40,-20},{44,-62}},
+          lineColor={255,255,255},
+          fillColor={255,0,0},
+          fillPattern=FillPattern.Solid,
+          textString="ERC"),
+        Polygon(
+          points={{-90,-86},{-58,-42},{60,-42},{98,-86},{-90,-86}},
+          pattern=LinePattern.None,
+          fillColor={0,0,0},
+          fillPattern=FillPattern.Solid),
+        Rectangle(
+          extent={{-54,-48},{-46,-54}},
+          pattern=LinePattern.None,
+          fillColor={215,215,215},
+          fillPattern=FillPattern.Solid,
+          lineColor={0,0,0}),
+        Rectangle(
+          extent={{-42,-48},{-34,-54}},
+          pattern=LinePattern.None,
+          fillColor={215,215,215},
+          fillPattern=FillPattern.Solid,
+          lineColor={0,0,0}),
+        Rectangle(
+          extent={{-30,-48},{-22,-54}},
+          pattern=LinePattern.None,
+          fillColor={215,215,215},
+          fillPattern=FillPattern.Solid,
+          lineColor={0,0,0}),
+        Rectangle(
+          extent={{-18,-48},{-10,-54}},
+          pattern=LinePattern.None,
+          fillColor={215,215,215},
+          fillPattern=FillPattern.Solid,
+          lineColor={0,0,0}),
+        Rectangle(
+          extent={{-6,-48},{2,-54}},
+          pattern=LinePattern.None,
+          fillColor={215,215,215},
+          fillPattern=FillPattern.Solid,
+          lineColor={0,0,0}),
+        Rectangle(
+          extent={{6,-48},{14,-54}},
+          pattern=LinePattern.None,
+          fillColor={215,215,215},
+          fillPattern=FillPattern.Solid,
+          lineColor={0,0,0}),
+        Rectangle(
+          extent={{18,-48},{26,-54}},
+          pattern=LinePattern.None,
+          fillColor={215,215,215},
+          fillPattern=FillPattern.Solid,
+          lineColor={0,0,0}),
+        Rectangle(
+          extent={{30,-48},{38,-54}},
+          pattern=LinePattern.None,
+          fillColor={215,215,215},
+          fillPattern=FillPattern.Solid,
+          lineColor={0,0,0}),
+        Rectangle(
+          extent={{42,-48},{50,-54}},
+          pattern=LinePattern.None,
+          fillColor={215,215,215},
+          fillPattern=FillPattern.Solid,
+          lineColor={0,0,0}),
+        Rectangle(
+          extent={{-62,-58},{-54,-64}},
+          pattern=LinePattern.None,
+          fillColor={215,215,215},
+          fillPattern=FillPattern.Solid,
+          lineColor={0,0,0}),
+        Rectangle(
+          extent={{-50,-58},{-42,-64}},
+          pattern=LinePattern.None,
+          fillColor={215,215,215},
+          fillPattern=FillPattern.Solid,
+          lineColor={0,0,0}),
+        Rectangle(
+          extent={{-38,-58},{-30,-64}},
+          pattern=LinePattern.None,
+          fillColor={215,215,215},
+          fillPattern=FillPattern.Solid,
+          lineColor={0,0,0}),
+        Rectangle(
+          extent={{-26,-58},{-18,-64}},
+          pattern=LinePattern.None,
+          fillColor={215,215,215},
+          fillPattern=FillPattern.Solid,
+          lineColor={0,0,0}),
+        Rectangle(
+          extent={{-14,-58},{-6,-64}},
+          pattern=LinePattern.None,
+          fillColor={215,215,215},
+          fillPattern=FillPattern.Solid,
+          lineColor={0,0,0}),
+        Rectangle(
+          extent={{-2,-58},{6,-64}},
+          pattern=LinePattern.None,
+          fillColor={215,215,215},
+          fillPattern=FillPattern.Solid,
+          lineColor={0,0,0}),
+        Rectangle(
+          extent={{10,-58},{18,-64}},
+          pattern=LinePattern.None,
+          fillColor={215,215,215},
+          fillPattern=FillPattern.Solid,
+          lineColor={0,0,0}),
+        Rectangle(
+          extent={{22,-58},{30,-64}},
+          pattern=LinePattern.None,
+          fillColor={215,215,215},
+          fillPattern=FillPattern.Solid,
+          lineColor={0,0,0}),
+        Rectangle(
+          extent={{34,-58},{42,-64}},
+          pattern=LinePattern.None,
+          fillColor={215,215,215},
+          fillPattern=FillPattern.Solid,
+          lineColor={0,0,0}),
+        Rectangle(
+          extent={{46,-58},{54,-64}},
+          pattern=LinePattern.None,
+          fillColor={215,215,215},
+          fillPattern=FillPattern.Solid,
+          lineColor={0,0,0}),
+        Rectangle(
+          extent={{58,-58},{66,-64}},
+          pattern=LinePattern.None,
+          fillColor={215,215,215},
+          fillPattern=FillPattern.Solid,
+          lineColor={0,0,0}),
+        Rectangle(
+          extent={{-72,-68},{-64,-74}},
+          pattern=LinePattern.None,
+          fillColor={215,215,215},
+          fillPattern=FillPattern.Solid,
+          lineColor={0,0,0}),
+        Rectangle(
+          extent={{-60,-68},{-52,-74}},
+          pattern=LinePattern.None,
+          fillColor={215,215,215},
+          fillPattern=FillPattern.Solid,
+          lineColor={0,0,0}),
+        Rectangle(
+          extent={{-48,-68},{-40,-74}},
+          pattern=LinePattern.None,
+          fillColor={215,215,215},
+          fillPattern=FillPattern.Solid,
+          lineColor={0,0,0}),
+        Rectangle(
+          extent={{-36,-68},{-28,-74}},
+          pattern=LinePattern.None,
+          fillColor={215,215,215},
+          fillPattern=FillPattern.Solid,
+          lineColor={0,0,0}),
+        Rectangle(
+          extent={{-24,-68},{-16,-74}},
+          pattern=LinePattern.None,
+          fillColor={215,215,215},
+          fillPattern=FillPattern.Solid,
+          lineColor={0,0,0}),
+        Rectangle(
+          extent={{-12,-68},{-4,-74}},
+          pattern=LinePattern.None,
+          fillColor={215,215,215},
+          fillPattern=FillPattern.Solid,
+          lineColor={0,0,0}),
+        Rectangle(
+          extent={{0,-68},{8,-74}},
+          pattern=LinePattern.None,
+          fillColor={215,215,215},
+          fillPattern=FillPattern.Solid,
+          lineColor={0,0,0}),
+        Rectangle(
+          extent={{12,-68},{20,-74}},
+          pattern=LinePattern.None,
+          fillColor={215,215,215},
+          fillPattern=FillPattern.Solid,
+          lineColor={0,0,0}),
+        Rectangle(
+          extent={{24,-68},{32,-74}},
+          pattern=LinePattern.None,
+          fillColor={215,215,215},
+          fillPattern=FillPattern.Solid,
+          lineColor={0,0,0}),
+        Rectangle(
+          extent={{36,-68},{44,-74}},
+          pattern=LinePattern.None,
+          fillColor={215,215,215},
+          fillPattern=FillPattern.Solid,
+          lineColor={0,0,0}),
+        Rectangle(
+          extent={{48,-68},{56,-74}},
+          pattern=LinePattern.None,
+          fillColor={215,215,215},
+          fillPattern=FillPattern.Solid,
+          lineColor={0,0,0}),
+        Rectangle(
+          extent={{60,-68},{68,-74}},
+          pattern=LinePattern.None,
+          fillColor={215,215,215},
+          fillPattern=FillPattern.Solid,
+          lineColor={0,0,0}),
+        Rectangle(
+          extent={{72,-68},{80,-74}},
+          pattern=LinePattern.None,
+          fillColor={215,215,215},
+          fillPattern=FillPattern.Solid,
+          lineColor={0,0,0}),
+        Rectangle(
+          extent={{-60,60},{60,-38}},
+          fillColor={175,175,175},
+          fillPattern=FillPattern.Solid,
+          pattern=LinePattern.None),
+        Rectangle(
+          extent={{-56,56},{56,-34}},
+          pattern=LinePattern.None,
+          fillColor={0,0,0},
+          fillPattern=FillPattern.Solid,
+          lineColor={0,0,0}),
+        Text(
+          extent={{-54,30},{58,-8}},
+          lineColor={255,0,0},
+          fillColor={215,215,215},
+          fillPattern=FillPattern.Solid,
+          textString="ERC")}),    Documentation(info="<html>
+<h4><span style=\"color: #008000\">Overview</span></h4>
+<p>Heat source with convective and radiative component. The load is determined
+by a schedule and the type of activity. </p>
+<h4><span style=\"color: #008000\">Concept</span></h4>
+<p>The schedule sets the times when the machines are used. They tend to be used
+more when people are present in the room, and go on stand-by when people are
+absent from the room. </p>
+<p>The schedule describes the machines corresponding to only one person, and can
+take values from 0 to 1. For more people, a factor, <b>NrPeople</b>, is provided
+as parameter.</p>
+<p>The type of activity determines the load for machines in the room for one
+person according to DIN 18599-10. The following values are used:</p>
+<table cellspacing=\"2\" cellpadding=\"0\" border=\"0\" summary = \"Load according to type of activity\"><tr>
+<td style=\"background-color: #dcdcdc\"><p>Activity Type</p></td>
+<td style=\"background-color: #dcdcdc\"><p>Heat Load [W]</p></td>
+</tr>
+<tr>
+<td><p>1</p></td>
+<td><p>50</p></td>
+</tr>
+<tr>
+<td><p>2</p></td>
+<td><p>100</p></td>
+</tr>
+<tr>
+<td><p>3</p></td>
+<td><p>150</p></td>
+</tr>
+</table>
+<p><br/><br/><br/><b><span style=\"color: #008000;\">Assumptions</span></b></p>
+<p>The surface for radiation exchange is constant throught the simulation, as
+the machines are always present in the room. For stability reasons a lower
+limitation of 1e-4 m2 has been introduced.</p>
+<h4><span style=\"color: #008000\">References</span></h4>
+<p>DIN 18599-10 </p>
+<h4><span style=\"color: #008000\">Example Results</span></h4>
+<p><a href=\"AixLib.Building.Examples.Sources.InternalGains.Machines\">AixLib.Building.Examples.Sources.InternalGains.Machines </a></p>
+<p><a href=\"AixLib.Building.Examples.Sources.InternalGains.OneOffice\">AixLib.Building.Examples.Sources.InternalGains.OneOffice</a></p>
+</html>",
+    revisions="<html>
+<ul>
+<li><i>October 19, 2016&nbsp;</i> by Ana Constantin:<br/>Corrected documentation to refer to machines directly</li>
+<li><i>October 21, 2014&nbsp;</i> by Ana Constantin:<br/>Added a lower positive limit to the surface area, so it will not lead to a division by zero</li>
+<li><i>Mai 19, 2014&nbsp;</i> by Ana Constantin:<br/>Uses components from MSL and respects the naming conventions</li>
+<li><i>May 07, 2013&nbsp;</i> by Ole Odendahl:<br/>Added documentation and formatted appropriately</li>
+</ul>
+</html>"));
+end MachinesAreaSpecific;

--- a/AixLib/Utilities/Sources/InternalGains/Machines/package.order
+++ b/AixLib/Utilities/Sources/InternalGains/Machines/package.order
@@ -1,3 +1,4 @@
 Machines_Avar
 Machines_DIN18599
 Machines_simple
+MachinesAreaSpecific


### PR DESCRIPTION
This pull request solves #690 and works in combination with [issue567](https://github.com/RWTH-EBC/TEASER/issues/567).

Plots of the convective heat flow by persons (upper graph) and machines (lower graph).

Calculation for Office Archetype with code from development branches of TEASER and AixLib: 
![office_alt](https://user-images.githubusercontent.com/44768823/53634634-f5abbd00-3c1a-11e9-928d-b8e9bc705139.PNG)

Calculation for Office Archetype with code from TEASER [issue567-Branch](https://github.com/RWTH-EBC/TEASER/tree/issue567_specific_persons_and_machines) and AixLib [issue690-Branch](https://github.com/RWTH-EBC/AixLib/tree/issue690_multizoneInternalGains):
![office_neu](https://user-images.githubusercontent.com/44768823/53634933-ea0cc600-3c1b-11e9-85e1-29a4f646262a.PNG)


