### PR TITLE
Remove extension of HeatPumpBaseDataDefinition for compatibility with OpenModelica

### DIFF
--- a/AixLib/DataBase/ThermalMachines/Chiller/ChillerBaseDataDefinition.mo
+++ b/AixLib/DataBase/ThermalMachines/Chiller/ChillerBaseDataDefinition.mo
@@ -1,10 +1,15 @@
 ﻿within AixLib.DataBase.ThermalMachines.Chiller;
 record ChillerBaseDataDefinition "Basic chiller data"
-    extends
-    AixLib.DataBase.ThermalMachines.HeatPump.HeatPumpBaseDataDefinition(
-                                                                tableQdot_con = tableQdot_eva);
 
+  extends Modelica.Icons.Record;
   parameter Real tableQdot_eva[:,:] "Cooling power table; T in degC; Q_flow in W";
+  parameter Real tableP_ele[:,:] "Electrical power table; T in degC; Q_flow in W";
+  parameter Modelica.SIunits.MassFlowRate mFlow_conNom
+    "Nominal mass flow rate in condenser";
+  parameter Modelica.SIunits.MassFlowRate mFlow_evaNom
+    "Nominal mass flow rate in evaporator";
+  parameter Real tableUppBou[:,2] "Points to define upper boundary for sink temperature";
+  parameter Real tableLowBou[:,2] "Points to define lower boundary for sink temperature";
 
   annotation (Documentation(info="<html>
 <p>Base data definition extending from the <a href=\"modelica://AixLib.DataBase.HeatPump.HeatPumpBaseDataDefinition\">HeatPumpBaseDataDefinition</a>, the parameters documentation is matched for a chiller. As a result, <span style=\"font-family: Courier New;\">tableQdot_eva</span> corresponds to the cooling capacity on the evaporator side of the chiller. Furthermore, the values of the tables depend on the condenser inlet temperature (defined in first row) and the evaporator outlet temperature (defined in first column) in W. </p>


### PR DESCRIPTION
As described in #864, defining **ChillerBaseDataDefinition** without extension of **HeatPumpBaseDataDefinition** seems to solve the issue of any models using the chiller not working in OpenModelica. I hope this PR is helpful.

closes #864 
