### PR TITLE
Add missing 'each' for compatibility with OpenModelica

### DIFF
--- a/AixLib/FastHVAC/Components/HeatGenerators/CHP/CHP_PT1.mo
+++ b/AixLib/FastHVAC/Components/HeatGenerators/CHP/CHP_PT1.mo
@@ -79,7 +79,7 @@ public
     FastHVAC.Interfaces.EnthalpyPort_a enthalpyPort_a
     annotation (Placement(transformation(extent={{-110,-10},{-90,10}})));
 
-    Modelica.Blocks.Interfaces.RealOutput Energy[3](unit="J")
+    Modelica.Blocks.Interfaces.RealOutput Energy[3](each unit="J")
     "1=W_el 2=Q_th 3=E_fuel"
     annotation (Placement(transformation(extent={{92,8},{132,48}}),
         iconTransformation(
@@ -88,7 +88,7 @@ public
         origin={102,-48})));
     Modelica.Blocks.Continuous.Integrator integrator[3]
       annotation (Placement(transformation(extent={{54,16},{74,36}})));
-    Modelica.Blocks.Interfaces.RealOutput Capacity[3](unit="W")
+    Modelica.Blocks.Interfaces.RealOutput Capacity[3](each unit="W")
     "1=P_el 2=dotQ_th 3=dotE_fuel" annotation (Placement(transformation(
           extent={{92,40},{132,80}}), iconTransformation(
         extent={{-10,-10},{10,10}},

--- a/AixLib/FastHVAC/Components/Storage/HeatStorageVariablePorts.mo
+++ b/AixLib/FastHVAC/Components/Storage/HeatStorageVariablePorts.mo
@@ -161,7 +161,7 @@ public
   Modelica.Thermal.HeatTransfer.Interfaces.HeatPort_a heatingRod if use_heatingRod annotation (Placement(transformation(
           extent={{-110,90},{-90,110}}),iconTransformation(extent={{-70,70},{-50,
             90}})));
-  Modelica.Blocks.Interfaces.RealOutput T_layers[n](  unit="K") annotation (Placement(
+  Modelica.Blocks.Interfaces.RealOutput T_layers[n](each unit="K") annotation (Placement(
         transformation(
         extent={{-10,-10},{10,10}},
         rotation=180,


### PR DESCRIPTION
Fixes the following and similar errors in OpenModelica:
`[AixLib.FastHVAC.Components.Storage.HeatStorageVariablePorts: 164:3-171:26]: Non-array modification ‘"K"‘ for array component ‘unit‘, possibly due to missing ‘each‘.`

closes #938
