### PR TITLE
Issue 1009 Replace mHC1_flow_nominal in HC2 with mHC2_flow_nominal

### DIFF
--- a/AixLib/Fluid/Storage/BufferStorage.mo
+++ b/AixLib/Fluid/Storage/BufferStorage.mo
@@ -36,7 +36,8 @@ model BufferStorage
 
   parameter SI.Temperature TStart=298.15 "Start Temperature of fluid" annotation (Dialog(tab="Initialization", group="Storage specific"));
 
-  replaceable parameter DataBase.Storage.BufferStorageBaseDataDefinition data constrainedby DataBase.Storage.BufferStorageBaseDataDefinition "Data record for Storage"
+  replaceable parameter DataBase.Storage.BufferStorageBaseDataDefinition data constrainedby
+    DataBase.Storage.BufferStorageBaseDataDefinition                                                                                         "Data record for Storage"
   annotation (choicesAllMatching);
 
   parameter Integer n(min=3)=5 " Model assumptions Number of Layers";
@@ -126,17 +127,20 @@ model BufferStorage
         extent={{-5,5},{5,-5}},
         rotation=0,
         origin={-80,-80})));
-  Modelica.Fluid.Interfaces.FluidPort_a fluidportTop1(  redeclare final package Medium =
+  Modelica.Fluid.Interfaces.FluidPort_a fluidportTop1(  redeclare final package
+                                                                                Medium =
                 Medium)
     "Fluid connector a (positive design flow direction is from port_a to port_b)"
     annotation (Placement(transformation(extent={{-38,92},{-18,110}},rotation=
            0), iconTransformation(extent={{-38,92},{-18,110}})));
-  Modelica.Fluid.Interfaces.FluidPort_a fluidportBottom2(redeclare final package Medium =
+  Modelica.Fluid.Interfaces.FluidPort_a fluidportBottom2(redeclare final
+      package                                                                    Medium =
                Medium)
     "Fluid connector a (positive design flow direction is from port_a to port_b)"
     annotation (Placement(transformation(extent={{14,-110},{32,-92}},rotation=
            0), iconTransformation(extent={{14,-110},{32,-92}})));
-  Modelica.Fluid.Interfaces.FluidPort_b fluidportBottom1(  redeclare final package Medium =
+  Modelica.Fluid.Interfaces.FluidPort_b fluidportBottom1(  redeclare final
+      package                                                                      Medium =
                  Medium)
     "Fluid connector b (positive design flow direction is from port_a to port_b)"
     annotation (Placement(transformation(extent={{-36,-112},{-18,-92}},
@@ -296,7 +300,7 @@ model BufferStorage
     pipeHC=data.pipeHC2,
     redeclare package Medium = MediumHC2,
     allowFlowReversal=true,
-    final m_flow_nominal=mHC1_flow_nominal,
+    final m_flow_nominal=mHC2_flow_nominal,
     TStart=TStart) if useHeatingCoil2
     annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},

--- a/AixLib/Fluid/Storage/Examples/BufferStorage.mo
+++ b/AixLib/Fluid/Storage/Examples/BufferStorage.mo
@@ -20,7 +20,8 @@ model BufferStorage
     upToDownHC1=false,
     upToDownHC2=false,
     useHeatingRod=false,
-    redeclare model HeatTransfer = AixLib.Fluid.Storage.BaseClasses.HeatTransferBuoyancyWetter,
+    redeclare model HeatTransfer =
+        AixLib.Fluid.Storage.BaseClasses.HeatTransferBuoyancyWetter,
     redeclare package MediumHC1 = Medium,
     redeclare package MediumHC2 = Medium,
     TStart=303.15) annotation (Placement(transformation(extent={{0,0},{-20,24}})));


### PR DESCRIPTION
For #1009

This solves issue 1009.
In the heating coil 2 the nominal mass flow rate was set to mHC1_flow_nominal which is the nominal mass flow rate of the first heating coil. 
It was replaced by the already existing parameter mHC2_flow_nominal.
