### PR TITLE
Travis: build with Python 3 (fixes master build)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - "2.7"
+  - "3.8"
 
 cache: pip
 

--- a/bin/runUnitTests.py
+++ b/bin/runUnitTests.py
@@ -43,9 +43,9 @@ def _validate_html(path):
     n_msg = len(errMsg)
     for i in range(n_msg):
         if i == 0:
-            print "The following malformed html syntax has been found:\n%s" % errMsg[i]
+            print("The following malformed html syntax has been found:\n%s" % errMsg[i])
         else:
-            print errMsg[i]
+            print(errMsg[i])
 
     if n_msg == 0:
         return 0
@@ -57,7 +57,7 @@ def _setEnvironmentVariables(var, value):
     '''
     import os
     import platform
-    if os.environ.has_key(var):
+    if var in os.environ:
         if platform.system() == "Windows":
             os.environ[var] = value + ";" + os.environ[var]
         else:


### PR DESCRIPTION
Travis CI for this project is configured to use Python 2.7 and [fails on `master`](https://travis-ci.org/github/RWTH-EBC/AixLib/jobs/734457254#L295), which is indicated by a read "build: failing" badge on this project's GitHub landing page. The underlying problem is this:

```
  File "/home/travis/virtualenv/python2.7.15/lib/python2.7/site-packages/buildingspy/development/validator.py", line 84, in _getInfoRevisionsHTML

    with open(moFile, mode="r", encoding="utf-8") as f:

TypeError: 'encoding' is an invalid keyword argument for this function
```

In Python 2.7, `open` does not accept an `encoding` parameter. In Python 3, it does.
https://docs.python.org/2.7/library/functions.html#open
https://docs.python.org/3.8/library/functions.html#open

Additionally, the call stack clearly shows that `open` is called from the BuildingsPy library.
The BuildingsPy library build instruction make it clear that Python 3 is required.
https://simulationresearch.lbl.gov/modelica/buildingspy/install.html

Python 3.9 is the latest and greatest Python 3 version, but it was released less than a week ago.
Python 3.8 was released a year ago and still receives bugfixes (as opposed to older versions which only receive security updates), so that seems like a good compromise.