### PR TITLE
Issue 1018: Division by zero error in valves

### DIFF
--- a/AixLib/Fluid/Actuators/Valves/TwoWayEqualPercentage.mo
+++ b/AixLib/Fluid/Actuators/Valves/TwoWayEqualPercentage.mo
@@ -2,7 +2,7 @@ within AixLib.Fluid.Actuators.Valves;
 model TwoWayEqualPercentage
   "Two way valve with equal percentage flow characteristics"
   extends BaseClasses.PartialTwoWayValveKv(
-    phi=max(0, if homotopyInitialization then
+    phi=max(0.1*l, if homotopyInitialization then
         homotopy(actual=AixLib.Fluid.Actuators.BaseClasses.equalPercentage(
         y_actual,
         R,

--- a/AixLib/Fluid/Actuators/Valves/TwoWayLinear.mo
+++ b/AixLib/Fluid/Actuators/Valves/TwoWayLinear.mo
@@ -1,6 +1,6 @@
 within AixLib.Fluid.Actuators.Valves;
 model TwoWayLinear "Two way valve with linear flow characteristics"
-  extends BaseClasses.PartialTwoWayValveKv(phi=max(0, l + y_actual*(1 - l)));
+  extends BaseClasses.PartialTwoWayValveKv(phi=max(0.1*l, l + y_actual*(1 - l)));
 
 initial equation
   // Since the flow model AixLib.Fluid.BaseClasses.FlowModels.basicFlowFunction_m_flow computes

--- a/AixLib/Fluid/Actuators/Valves/TwoWayPolynomial.mo
+++ b/AixLib/Fluid/Actuators/Valves/TwoWayPolynomial.mo
@@ -1,7 +1,7 @@
 within AixLib.Fluid.Actuators.Valves;
 model TwoWayPolynomial "Two way valve with polynomial characteristic"
   extends AixLib.Fluid.Actuators.BaseClasses.PartialTwoWayValveKv(
-    phi=max(0, l + pol_y*(1 - l)));
+    phi=max(0.1*l, l + pol_y*(1 - l)));
 
   parameter Real[:] c
     "Polynomial coefficients, starting with fixed offset";

--- a/AixLib/Fluid/Actuators/Valves/TwoWayPressureIndependent.mo
+++ b/AixLib/Fluid/Actuators/Valves/TwoWayPressureIndependent.mo
@@ -3,7 +3,7 @@ model TwoWayPressureIndependent "Model of a pressure-independent two way valve"
   extends AixLib.Fluid.Actuators.BaseClasses.PartialTwoWayValve(
             final linearized = false,
             from_dp=true,
-            phi=max(0, l + y_actual*(1 - l)));
+            phi=max(0.1*l, l + y_actual*(1 - l)));
 
   parameter Real l2(min=1e-10) = 0.01
     "Gain for mass flow increase if pressure is above nominal pressure"

--- a/AixLib/Fluid/Actuators/Valves/TwoWayQuickOpening.mo
+++ b/AixLib/Fluid/Actuators/Valves/TwoWayQuickOpening.mo
@@ -2,7 +2,7 @@ within AixLib.Fluid.Actuators.Valves;
 model TwoWayQuickOpening
   "Two way valve with quick opening flow characteristics"
   extends BaseClasses.PartialTwoWayValveKv(
-    phi=max(0,
+    phi=max(0.1*l,
          if homotopyInitialization then
            homotopy(
              actual=l + Modelica.Fluid.Utilities.regPow(

--- a/AixLib/Fluid/Actuators/Valves/TwoWayTable.mo
+++ b/AixLib/Fluid/Actuators/Valves/TwoWayTable.mo
@@ -1,7 +1,7 @@
 within AixLib.Fluid.Actuators.Valves;
 model TwoWayTable "Two way valve with table-specified flow characteristics"
   extends BaseClasses.PartialTwoWayValveKv(
-    phi=max(0, phiLooUp.y[1]),
+    phi=max(0.1*l, phiLooUp.y[1]),
     final l = phiLooUp.table[1, 2]);
   parameter Data.Generic flowCharacteristics "Table with flow characteristics"
     annotation (choicesAllMatching=true, Placement(transformation(extent={{-80,


### PR DESCRIPTION
This closes #1018 

Due to a max function for the calculation of phi with zero as one option, division by zero occurs during simulation of hydraulic networks using the following valve models:

- AixLib.Fluid.Actuators.Valves.TwoWayEqualPercentage
- AixLib.Fluid.Actuators.Valves.TwoWayLinear
- AixLib.Fluid.Actuators.Valves.TwoWayPolynomial
- AixLib.Fluid.Actuators.Valves.TwoWayPressureIndependent
- AixLib.Fluid.Actuators.Valves.TwoWayQuickOpening
- AixLib.Fluid.Actuators.Valves.TwoWayTable

I changed the input of the max function as follows:
`extends BaseClasses.PartialTwoWayValveKv(phi=max(0.1*l, l + y_actual*(1 - l)))` instead of
`extends BaseClasses.PartialTwoWayValveKv(phi=max(0, l + y_actual*(1 - l)))`
