### PR TITLE
Update package.mo

### DIFF
--- a/AixLib/package.mo
+++ b/AixLib/package.mo
@@ -7,7 +7,7 @@ package AixLib
     NcDataReader2(version="2.5.0"),
     SDF(version="0.4.1"),
     Modelica_DeviceDrivers(version="1.7.0")),
-  version = "0.11.1",
+  version = "0.12.0",
   conversion(from(
     version="0.3.2",
                      script="modelica://AixLib/Resources/Scripts/ConvertAixLib_from_0.3.2_to_0.4.mos",


### PR DESCRIPTION
Hotfix, because the automatic IBPSA merge created the conversion script but didn't raised the AixLib version to v0.12.0.