### PR TITLE
Add again missing 'each' for OM #1055 [skip ci]

### DIFF
--- a/AixLib/Obsolete/YearIndependent/FastHVAC/Components/HeatGenerators/CHP/CHP_PT1.mo
+++ b/AixLib/Obsolete/YearIndependent/FastHVAC/Components/HeatGenerators/CHP/CHP_PT1.mo
@@ -83,7 +83,7 @@ public
     FastHVAC.Interfaces.EnthalpyPort_a enthalpyPort_a annotation (
       Placement(transformation(extent={{-110,-10},{-90,10}})));
 
-    Modelica.Blocks.Interfaces.RealOutput Energy[3](unit="J")
+    Modelica.Blocks.Interfaces.RealOutput Energy[3](each unit="J")
     "1=W_el 2=Q_th 3=E_fuel"
     annotation (Placement(transformation(extent={{92,8},{132,48}}),
         iconTransformation(
@@ -92,7 +92,7 @@ public
         origin={102,-48})));
     Modelica.Blocks.Continuous.Integrator integrator[3]
       annotation (Placement(transformation(extent={{54,16},{74,36}})));
-    Modelica.Blocks.Interfaces.RealOutput Capacity[3](unit="W")
+    Modelica.Blocks.Interfaces.RealOutput Capacity[3](each unit="W")
     "1=P_el 2=dotQ_th 3=dotE_fuel" annotation (Placement(transformation(
           extent={{92,40},{132,80}}), iconTransformation(
         extent={{-10,-10},{10,10}},

--- a/AixLib/Obsolete/YearIndependent/FastHVAC/Components/Storage/HeatStorageVariablePorts.mo
+++ b/AixLib/Obsolete/YearIndependent/FastHVAC/Components/Storage/HeatStorageVariablePorts.mo
@@ -160,7 +160,7 @@ public
   Modelica.Thermal.HeatTransfer.Interfaces.HeatPort_a heatingRod if use_heatingRod annotation (Placement(transformation(
           extent={{-110,90},{-90,110}}),iconTransformation(extent={{-70,70},{-50,
             90}})));
-  Modelica.Blocks.Interfaces.RealOutput T_layers[n](  unit="K") annotation (Placement(
+  Modelica.Blocks.Interfaces.RealOutput T_layers[n](each unit="K") annotation (Placement(
         transformation(
         extent={{-10,-10},{10,10}},
         rotation=180,


### PR DESCRIPTION
This PR just duplicates what pr #939 does which was somehow lost.

Closes #1055 