### PR TITLE
Add parameter withAirCap to ThermalZones.ZoneRecordDummy #1096

### DIFF
--- a/AixLib/DataBase/ThermalZones/ZoneRecordDummy.mo
+++ b/AixLib/DataBase/ThermalZones/ZoneRecordDummy.mo
@@ -2,6 +2,7 @@ within AixLib.DataBase.ThermalZones;
 record ZoneRecordDummy "This is a dummy record with non-physical parameter values."
   extends AixLib.DataBase.ThermalZones.ZoneBaseRecord(
     T_start=Modelica.Constants.eps,
+    withAirCap=true,
     VAir=Modelica.Constants.inf,
     AZone=Modelica.Constants.inf,
     hRad=Modelica.Constants.eps,


### PR DESCRIPTION
Add parameter "withAirCap = true" to ThermalZones.ZoneRecordDummy. Further parameters shadingFactor and maxIrr are already implemented in ThermalZones.ZoneRecordDummy.

closes #1096 