### PR TITLE
 Missing conversion script for Obsolete packages #895

### DIFF
--- a/AixLib/Resources/Scripts/ConvertAixLib_from_0.7.9_to_0.7.10.mos
+++ b/AixLib/Resources/Scripts/ConvertAixLib_from_0.7.9_to_0.7.10.mos
@@ -1,3 +1,7 @@
+// add missing convert class for HumanSensibleHeat_VDI2078
+convertClass("AixLib.Utilities.Sources.InternalGains.Humans.HumanSensibleHeat_VDI2078",
+			 "AixLib.Utilities.Sources.InternalGains.Humans.Obsolete.HumanSensibleHeat_VDI2078");
+
 // correct renaming of hRad
 convertElement("AixLib.DataBase.ThermalZones.OfficePassiveHouse.OPH_1_Office","hConvRadWall","hRadWall");
 convertElement("AixLib.DataBase.ThermalZones.ZoneBaseRecord","hConvRadWall","hRadWall");


### PR DESCRIPTION
Added convertClass("AixLib.Utilities.Sources.InternalGains.Humans.HumanSensibleHeat_VDI2078", "AixLib.Utilities.Sources.InternalGains.Humans.Obsolete.HumanSensibleHeat_VDI2078"); to the conversion script 0.7.9_to_0.7.10, because change from Martin Kremer was made on version 0.7.9 at 19.07.2019 (0.7.8_to_0.7.9 published on 12.07.2019).

closes #895 