### PR TITLE
Change command convertClass to ConvertModifiers

### DIFF
--- a/AixLib/Resources/Scripts/ConvertAixLib_from_1.0.3_to_1.1.0.mos
+++ b/AixLib/Resources/Scripts/ConvertAixLib_from_1.0.3_to_1.1.0.mos
@@ -6,36 +6,35 @@ clear
 convertClear();
 
 // Conversion for https://github.com/ibpsa/modelica-ibpsa/issues/1542
-convertClass("AixLib.Airflow.Multizone.MediumColumnDynamic", {"massDynamics"}, fill("",0), true);
-convertClass("AixLib.Fluid.Actuators.Valves.ThreeWayEqualPercentageLinear", {"massDynamics"}, fill("",0), true);
-convertClass("AixLib.Fluid.Actuators.Valves.ThreeWayLinear", {"massDynamics"}, fill("",0), true);
-convertClass("AixLib.Fluid.Actuators.Valves.ThreeWayTable", {"massDynamics"}, fill("",0), true);
-convertClass("AixLib.Fluid.HeatExchangers.Radiators.RadiatorEN442_2", {"massDynamics"}, fill("",0), true);
-convertClass("AixLib.Fluid.Movers.FlowControlled_dp", {"massDynamics"}, fill("",0), true);
-convertClass("AixLib.Fluid.Movers.FlowControlled_m_flow", {"massDynamics"}, fill("",0), true);
-convertClass("AixLib.Fluid.Movers.SpeedControlled_Nrpm", {"massDynamics"}, fill("",0), true);
-convertClass("AixLib.Fluid.Movers.SpeedControlled_y", {"massDynamics"}, fill("",0), true);
-convertClass("AixLib.Fluid.Storage.Stratified", {"massDynamics"}, fill("",0), true);
-convertClass("AixLib.Fluid.Storage.StratifiedEnhanced", {"massDynamics"}, fill("",0), true);
-convertClass("AixLib.Fluid.Storage.StratifiedEnhancedInternalHex", {"massDynamics"}, fill("",0), true);
-convertClass("AixLib.Fluid.HeatExchangers.EvaporatorCondenser", {"massDynamics"}, fill("",0), true);
-convertClass("AixLib.Fluid.HeatExchangers.HeaterCooler_u", {"massDynamics"}, fill("",0), true);
-convertClass("AixLib.Fluid.Humidifiers.Humidifier_u", {"massDynamics"}, fill("",0), true);
-convertClass("AixLib.Fluid.Interfaces.TwoPortHeatMassExchanger", {"massDynamics"}, fill("",0), true);
-convertClass("AixLib.Fluid.Geothermal.Borefields.BaseClasses.Boreholes.BaseClasses.InternalHEXOneUTube", {"massDynamics"}, fill("",0), true);
-convertClass("AixLib.Fluid.Geothermal.Borefields.BaseClasses.Boreholes.BaseClasses.InternalHEXTwoUTube", {"massDynamics"}, fill("",0), true);
-convertClass("AixLib.Fluid.HeatExchangers.PrescribedOutlet", {"massDynamics"}, fill("",0), true);
-convertClass("AixLib.Fluid.Interfaces.PrescribedOutlet", {"massDynamics"}, fill("",0), true);
-convertClass("AixLib.ThermalZones.ReducedOrder.RC.FourElements", {"massDynamics"}, fill("",0), true);
-convertClass("AixLib.ThermalZones.ReducedOrder.RC.OneElement", {"massDynamics"}, fill("",0), true);
-convertClass("AixLib.ThermalZones.ReducedOrder.RC.ThreeElements", {"massDynamics"}, fill("",0), true);
-convertClass("AixLib.ThermalZones.ReducedOrder.RC.TwoElements", {"massDynamics"}, fill("",0), true);
-convertClass("AixLib.Fluid.HeatExchangers.ActiveBeams.Cooling", {"massDynamics"}, fill("",0), true);
-convertClass("AixLib.Fluid.HeatExchangers.ActiveBeams.CoolingAndHeating", {"massDynamics"}, fill("",0), true);
-convertClass("AixLib.Fluid.HeatExchangers.WetCoilEffectivenessNTU", {"massDynamics"}, fill("",0), true);
-convertClass("AixLib.Fluid.Delays.DelayFirstOrder", {"massDynamics"}, fill("",0), true);
+ConvertModifiers("AixLib.Airflow.Multizone.MediumColumnDynamic", {"massDynamics"}, fill("",0), true);
+ConvertModifiers("AixLib.Fluid.Actuators.Valves.ThreeWayEqualPercentageLinear", {"massDynamics"}, fill("",0), true);
+ConvertModifiers("AixLib.Fluid.Actuators.Valves.ThreeWayLinear", {"massDynamics"}, fill("",0), true);
+ConvertModifiers("AixLib.Fluid.Actuators.Valves.ThreeWayTable", {"massDynamics"}, fill("",0), true);
+ConvertModifiers("AixLib.Fluid.HeatExchangers.Radiators.RadiatorEN442_2", {"massDynamics"}, fill("",0), true);
+ConvertModifiers("AixLib.Fluid.Movers.FlowControlled_dp", {"massDynamics"}, fill("",0), true);
+ConvertModifiers("AixLib.Fluid.Movers.FlowControlled_m_flow", {"massDynamics"}, fill("",0), true);
+ConvertModifiers("AixLib.Fluid.Movers.SpeedControlled_Nrpm", {"massDynamics"}, fill("",0), true);
+ConvertModifiers("AixLib.Fluid.Movers.SpeedControlled_y", {"massDynamics"}, fill("",0), true);
+ConvertModifiers("AixLib.Fluid.Storage.Stratified", {"massDynamics"}, fill("",0), true);
+ConvertModifiers("AixLib.Fluid.Storage.StratifiedEnhanced", {"massDynamics"}, fill("",0), true);
+ConvertModifiers("AixLib.Fluid.Storage.StratifiedEnhancedInternalHex", {"massDynamics"}, fill("",0), true);
+ConvertModifiers("AixLib.Fluid.HeatExchangers.EvaporatorCondenser", {"massDynamics"}, fill("",0), true);
+ConvertModifiers("AixLib.Fluid.HeatExchangers.HeaterCooler_u", {"massDynamics"}, fill("",0), true);
+ConvertModifiers("AixLib.Fluid.Interfaces.TwoPortHeatMassExchanger", {"massDynamics"}, fill("",0), true);
+ConvertModifiers("AixLib.Fluid.Geothermal.Borefields.BaseClasses.Boreholes.BaseClasses.InternalHEXOneUTube", {"massDynamics"}, fill("",0), true);
+ConvertModifiers("AixLib.Fluid.Geothermal.Borefields.BaseClasses.Boreholes.BaseClasses.InternalHEXTwoUTube", {"massDynamics"}, fill("",0), true);
+ConvertModifiers("AixLib.Fluid.HeatExchangers.PrescribedOutlet", {"massDynamics"}, fill("",0), true);
+ConvertModifiers("AixLib.Fluid.Interfaces.PrescribedOutlet", {"massDynamics"}, fill("",0), true);
+ConvertModifiers("AixLib.ThermalZones.ReducedOrder.RC.FourElements", {"massDynamics"}, fill("",0), true);
+ConvertModifiers("AixLib.ThermalZones.ReducedOrder.RC.OneElement", {"massDynamics"}, fill("",0), true);
+ConvertModifiers("AixLib.ThermalZones.ReducedOrder.RC.ThreeElements", {"massDynamics"}, fill("",0), true);
+ConvertModifiers("AixLib.ThermalZones.ReducedOrder.RC.TwoElements", {"massDynamics"}, fill("",0), true);
+ConvertModifiers("AixLib.Fluid.HeatExchangers.ActiveBeams.Cooling", {"massDynamics"}, fill("",0), true);
+ConvertModifiers("AixLib.Fluid.HeatExchangers.ActiveBeams.CoolingAndHeating", {"massDynamics"}, fill("",0), true);
+ConvertModifiers("AixLib.Fluid.HeatExchangers.WetCoilEffectivenessNTU", {"massDynamics"}, fill("",0), true);
+ConvertModifiers("AixLib.Fluid.Delays.DelayFirstOrder", {"massDynamics"}, fill("",0), true);
 
-convertClass("AixLib.Fluid.Storage.StratifiedEnhancedInternalHex", {"massDynamicsHex"}, fill("",0), true);
+ConvertModifiers("AixLib.Fluid.Storage.StratifiedEnhancedInternalHex", {"massDynamicsHex"}, fill("",0), true);
 
 convertElement("AixLib.Fluid.Humidifiers.SteamHumidifier_X",
   "massDynamics",

--- a/AixLib/Resources/Scripts/ConvertAixLib_from_1.2.0_to_1.2.1.mos
+++ b/AixLib/Resources/Scripts/ConvertAixLib_from_1.2.0_to_1.2.1.mos
@@ -2,4 +2,4 @@ clear
 
 convertClear();
 
-convertClass("AixLib.Fluid.Interfaces.LumpedVolumeDeclarations", {"massDynamics"}, fill("",0), true);
+ConvertModifiers("AixLib.Fluid.Interfaces.LumpedVolumeDeclarations", {"massDynamics"}, fill("",0), true);

--- a/bin/templates/03_ci_templates/01_deploy/gitlab_pages.gitlab-ci.yml
+++ b/bin/templates/03_ci_templates/01_deploy/gitlab_pages.gitlab-ci.yml
@@ -15,5 +15,9 @@ pages:
          - public
          
         expire_in: 7h
+    except:
+        refs:
+            - master
+            - development
     when: always
     allow_failure: true 

--- a/bin/templates/03_ci_templates/01_deploy/gitlab_pages.txt
+++ b/bin/templates/03_ci_templates/01_deploy/gitlab_pages.txt
@@ -15,5 +15,9 @@ pages:
          - public
          
         expire_in: 7h
+    except:
+        refs:
+            - master
+            - development
     when: always
     allow_failure: true 

--- a/bin/templates/03_ci_templates/02_UnitTests/check_model.gitlab-ci.yml
+++ b/bin/templates/03_ci_templates/02_UnitTests/check_model.gitlab-ci.yml
@@ -38,6 +38,9 @@ stages:
             - $CI_COMMIT_MESSAGE  =~ /ci_create_html_whitelist/
             - $CI_COMMIT_MESSAGE  =~ /ci_html/
             - $CI_COMMIT_MESSAGE  =~ /ci_setting/
+        refs:
+            - master
+            - development
             
 Check_AixLib_Airflow:
     variables:
@@ -85,6 +88,75 @@ Check_AixLib_Utilities:
     extends: .check_model_job
 
 
+.dev_check_model_job:
+    stage: check
+    before_script:
+        - export PIP_CACHE_DIR="/opt/cache/pip"
+        - source activate myenv
+        - pip install natsort
+        - export PYTHONIOENCODING=utf-8 # just in case
+    script:
+        - xvfb-run -n 77 python bin/CITests/02_UnitTests/CheckPackages/validatetest.py  --single-package "${lib_package}" --library AixLib -DS 2022 --wh-library IBPSA --filterwhitelist
+
+    artifacts:
+        when: on_failure
+        paths:
+            - AixLib/AixLib.${lib_package}-log.txt
+            - AixLib/AixLib.${lib_package}-errorlog.txt
+        expire_in: 7 day
+    only:
+        - master
+        - development
+    retry:
+        max: 2
+        when: runner_system_failure
+
+Development_Check_AixLib_Airflow:
+    variables:
+        lib_package: Airflow
+    extends: .dev_check_model_job
+
+Development_Check_AixLib_BoundaryConditions:
+    variables:
+        lib_package: BoundaryConditions
+    extends: .dev_check_model_job
+
+Development_Check_AixLib_Controls:
+    variables:
+        lib_package: Controls
+    extends: .dev_check_model_job
+
+Development_Check_AixLib_Electrical:
+    variables:
+        lib_package: Electrical
+    extends: .dev_check_model_job
+
+Development_Check_AixLib_Fluid:
+    variables:
+        lib_package: Fluid
+    extends: .dev_check_model_job
+
+Development_Check_AixLib_Media:
+    variables:
+        lib_package: Media
+    extends: .dev_check_model_job
+
+Development_Check_AixLib_Systems:
+    variables:
+        lib_package: Systems
+    extends: .dev_check_model_job
+
+Development_Check_AixLib_ThermalZones:
+    variables:
+        lib_package: ThermalZones
+    extends: .dev_check_model_job
+
+Development_Check_AixLib_Utilities:
+    variables:
+        lib_package: Utilities
+    extends: .dev_check_model_job
+
+
 .check_changed_models_job:
     stage: check
     before_script:
@@ -105,6 +177,8 @@ Check_AixLib_Utilities:
         refs:
             - external_pull_requests
             - IBPSA_Merge
+            - master
+            - development
         variables:
             - $CI_COMMIT_MESSAGE  =~ /ci_update_ref/
             - $CI_COMMIT_MESSAGE  =~ /ci_dif_ref/
@@ -319,3 +393,4 @@ whitelist_job:
     except:
         refs:
             - external_pull_requests
+

--- a/bin/templates/03_ci_templates/02_UnitTests/check_model.gitlab-ci.yml
+++ b/bin/templates/03_ci_templates/02_UnitTests/check_model.gitlab-ci.yml
@@ -105,8 +105,9 @@ Check_AixLib_Utilities:
             - AixLib/AixLib.${lib_package}-errorlog.txt
         expire_in: 7 day
     only:
-        - master
-        - development
+        refs:
+            - master
+            - development
     retry:
         max: 2
         when: runner_system_failure

--- a/bin/templates/03_ci_templates/02_UnitTests/check_model.txt
+++ b/bin/templates/03_ci_templates/02_UnitTests/check_model.txt
@@ -28,12 +28,46 @@ stages:
             %for commit in except_commit_list:
             - $CI_COMMIT_MESSAGE  =~ /${commit}/
             %endfor
+        refs:
+            - master
+            - development
             
 %for package in package_list:
 Check_${library}_${package}:
     variables:
         lib_package: ${package}
     extends: .check_model_job
+
+%endfor
+
+.dev_check_model_job:
+    stage: check
+    before_script:
+        - export PIP_CACHE_DIR="/opt/cache/pip"
+        - source activate ${python_version}
+        - pip install natsort
+        - export PYTHONIOENCODING=utf-8 # just in case
+    script:
+        - xvfb-run -n 77 python bin/CITests/02_UnitTests/CheckPackages/validatetest.py  --single-package "${lib_package}" --library ${library} -DS ${dymolaversion} ${wh_flag} ${filterflag}
+
+    artifacts:
+        when: on_failure
+        paths:
+            - ${library}/${library}.${lib_package}-log.txt
+            - ${library}/${library}.${lib_package}-errorlog.txt
+        expire_in: 7 day
+    only:
+        - master
+        - development
+    retry:
+        max: 2
+        when: runner_system_failure
+
+%for package in package_list:
+Development_Check_${library}_${package}:
+    variables:
+        lib_package: ${package}
+    extends: .dev_check_model_job
 
 %endfor
 
@@ -57,6 +91,8 @@ Check_${library}_${package}:
         refs:
             - external_pull_requests
             ${merge_branch}
+            - master
+            - development
         variables:
             %for commit in except_commit_list:
             - $CI_COMMIT_MESSAGE  =~ /${commit}/
@@ -161,3 +197,4 @@ whitelist_job:
     except:
         refs:
             - external_pull_requests
+

--- a/bin/templates/03_ci_templates/02_UnitTests/check_model.txt
+++ b/bin/templates/03_ci_templates/02_UnitTests/check_model.txt
@@ -57,8 +57,9 @@ Check_${library}_${package}:
             - ${library}/${library}.${lib_package}-errorlog.txt
         expire_in: 7 day
     only:
-        - master
-        - development
+        refs:
+            - master
+            - development
     retry:
         max: 2
         when: runner_system_failure

--- a/bin/templates/03_ci_templates/02_UnitTests/regression_test.gitlab-ci.yml
+++ b/bin/templates/03_ci_templates/02_UnitTests/regression_test.gitlab-ci.yml
@@ -44,6 +44,9 @@ stages:
         max: 2
         when: runner_system_failure
 
+
+
+
 CI_Regressiontest_AixLib_Airflow:
     variables:
         lib_package: AixLib.Airflow
@@ -88,6 +91,93 @@ CI_Regressiontest_AixLib_Utilities:
     variables:
         lib_package: AixLib.Utilities
     extends: .CI_Regressiontest
+
+
+
+
+.dev_Regressiontest:
+    stage: RegressionTest
+    before_script:
+        - export PIP_CACHE_DIR="/opt/cache/pip"
+        - source activate myenv
+        - pip install --upgrade git+https://github.com/MichaMans/BuildingsPy@testexamplescoverage
+        - export PYTHONIOENCODING=utf-8 # just in case
+        - echo 'FAIL' > bin/Configfiles/exit.sh
+    script:
+        - cd AixLib && xvfb-run -n 77 python ../bin/CITests/02_UnitTests/reference_check.py -n 4 --tool dymola --single-package "${lib_package}" --library AixLib --batch -DS 2022
+        - cd .. && echo 'successful' > bin/Configfiles/exit.sh
+    after_script:
+        - if cat bin/Configfiles/exit.sh | grep "FAIL"; then
+            export PIP_CACHE_DIR="/opt/cache/pip" ;
+            source activate myenv ;
+            pip install pandas mako matplot ;
+            python bin/CITests/05_Converter/google_charts.py --line-html --error --funnel-comp --single-package ${lib_package} ;
+            mkdir -p data ;
+            cp -r AixLib/simulator-dymola.log data ;
+            cp -r AixLib/unitTests-dymola.log data ;
+            cp -r AixLib/funnel_comp data ;
+          else
+            echo "Test was succesful!" ;
+          fi
+    artifacts:
+        when: on_failure
+        paths:
+          - data
+          - bin/templates/02_charts/${lib_package}
+        expire_in: 7 day
+    only:
+        refs:
+            - development
+            - master
+    retry:
+        max: 2
+        when: runner_system_failure
+
+Development_Regressiontest_AixLib_Airflow:
+    variables:
+        lib_package: AixLib.Airflow
+    extends: .dev_Regressiontest
+
+Development_Regressiontest_AixLib_BoundaryConditions:
+    variables:
+        lib_package: AixLib.BoundaryConditions
+    extends: .dev_Regressiontest
+
+Development_Regressiontest_AixLib_Controls:
+    variables:
+        lib_package: AixLib.Controls
+    extends: .dev_Regressiontest
+
+Development_Regressiontest_AixLib_Electrical:
+    variables:
+        lib_package: AixLib.Electrical
+    extends: .dev_Regressiontest
+
+Development_Regressiontest_AixLib_Fluid:
+    variables:
+        lib_package: AixLib.Fluid
+    extends: .dev_Regressiontest
+
+Development_Regressiontest_AixLib_Media:
+    variables:
+        lib_package: AixLib.Media
+    extends: .dev_Regressiontest
+
+Development_Regressiontest_AixLib_Systems:
+    variables:
+        lib_package: AixLib.Systems
+    extends: .dev_Regressiontest
+
+Development_Regressiontest_AixLib_ThermalZones:
+    variables:
+        lib_package: AixLib.ThermalZones
+    extends: .dev_Regressiontest
+
+Development_Regressiontest_AixLib_Utilities:
+    variables:
+        lib_package: AixLib.Utilities
+    extends: .dev_Regressiontest
+
 
 
 CI_create_plots:
@@ -181,6 +271,10 @@ CI_create_plots:
             - $CI_COMMIT_MESSAGE  =~ /ci_create_html_whitelist/
             - $CI_COMMIT_MESSAGE  =~ /ci_html/
             - $CI_COMMIT_MESSAGE  =~ /ci_setting/
+        refs:
+            - master
+            - development
+
     retry:
         max: 2
         when: runner_system_failure
@@ -264,6 +358,9 @@ Regression_overall_coverage:
             - $CI_COMMIT_MESSAGE  =~ /ci_create_html_whitelist/
             - $CI_COMMIT_MESSAGE  =~ /ci_html/
             - $CI_COMMIT_MESSAGE  =~ /ci_setting/
+        refs:
+            - master
+            - development
     retry:
         max: 2
         when: runner_system_failure
@@ -303,6 +400,9 @@ prepare_create_plots:
             - $CI_COMMIT_MESSAGE  =~ /ci_create_html_whitelist/
             - $CI_COMMIT_MESSAGE  =~ /ci_html/
             - $CI_COMMIT_MESSAGE  =~ /ci_setting/
+        refs:
+            - master
+            - development
     when: on_failure
     needs:
     - job: Regressiontest_AixLib_Airflow
@@ -359,6 +459,8 @@ prepare_create_plots:
         refs:
             - external_pull_requests
             - IBPSA_Merge
+            - master
+            - development
         variables:
             - $CI_COMMIT_MESSAGE  =~ /ci_update_ref/
             - $CI_COMMIT_MESSAGE  =~ /ci_dif_ref/
@@ -448,6 +550,8 @@ Changed_create_plots:
         refs:
             - external_pull_requests
             - IBPSA_Merge
+            - master
+            - development
         variables:
             - $CI_COMMIT_MESSAGE  =~ /ci_update_ref/
             - $CI_COMMIT_MESSAGE  =~ /ci_dif_ref/
@@ -554,6 +658,8 @@ RegressionTest_Check_References:
     except:
         refs:
             - IBPSA_Merge
+            - master
+            - development
         variables:
             - $CI_COMMIT_MESSAGE  =~ /ci_update_ref/
             - $CI_COMMIT_MESSAGE  =~ /ci_dif_ref/

--- a/bin/templates/03_ci_templates/02_UnitTests/regression_test.txt
+++ b/bin/templates/03_ci_templates/02_UnitTests/regression_test.txt
@@ -44,6 +44,9 @@ stages:
         max: 2
         when: runner_system_failure
 
+
+
+
 %for package in package_list:
 CI_Regressiontest_${library}_${package}:
     variables:
@@ -51,6 +54,55 @@ CI_Regressiontest_${library}_${package}:
     extends: .CI_Regressiontest
 
 %endfor
+
+
+
+.dev_Regressiontest:
+    stage: RegressionTest
+    before_script:
+        - export PIP_CACHE_DIR="/opt/cache/pip"
+        - source activate ${python_version}
+        - pip install --upgrade git+https://github.com/MichaMans/BuildingsPy@testexamplescoverage
+        - export PYTHONIOENCODING=utf-8 # just in case
+        - echo 'FAIL' > ${exit_file}
+    script:
+        - cd ${library} && xvfb-run -n 77 python ../bin/CITests/02_UnitTests/reference_check.py -n 4 --tool dymola --single-package "${lib_package}" --library ${library} --batch -DS ${dymolaversion}
+        - cd .. && echo 'successful' > ${exit_file}
+    after_script:
+        - if cat ${exit_file} | grep "FAIL"; then
+            export PIP_CACHE_DIR="/opt/cache/pip" ;
+            source activate ${python_version} ;
+            pip install pandas mako matplot ;
+            python bin/CITests/05_Converter/google_charts.py --line-html --error --funnel-comp --single-package ${lib_package} ;
+            mkdir -p data ;
+            cp -r ${library}/simulator-dymola.log data ;
+            cp -r ${library}/unitTests-dymola.log data ;
+            cp -r ${library}/funnel_comp data ;
+          else
+            echo "Test was succesful!" ;
+          fi
+    artifacts:
+        when: on_failure
+        paths:
+          - data
+          - ${chart_dir}/${lib_package}
+        expire_in: 7 day
+    only:
+        refs:
+            - development
+            - master
+    retry:
+        max: 2
+        when: runner_system_failure
+
+%for package in package_list:
+Development_Regressiontest_${library}_${package}:
+    variables:
+        lib_package: ${library}.${package}
+    extends: .dev_Regressiontest
+
+%endfor
+
 
 CI_create_plots:
     stage: prepare
@@ -119,6 +171,10 @@ CI_create_plots:
             %for commit in except_commit_list:
             - $CI_COMMIT_MESSAGE  =~ /${commit}/
             %endfor
+        refs:
+            - master
+            - development
+
     retry:
         max: 2
         when: runner_system_failure
@@ -154,6 +210,9 @@ Regression_overall_coverage:
             %for commit in except_commit_list:
             - $CI_COMMIT_MESSAGE  =~ /${commit}/
             %endfor
+        refs:
+            - master
+            - development
     retry:
         max: 2
         when: runner_system_failure
@@ -183,6 +242,9 @@ prepare_create_plots:
             %for commit in except_commit_list:
             - $CI_COMMIT_MESSAGE  =~ /${commit}/
             %endfor
+        refs:
+            - master
+            - development
     when: on_failure
     needs:
     %for package in package_list:
@@ -225,6 +287,8 @@ prepare_create_plots:
         refs:
             - external_pull_requests
             ${merge_branch}
+            - master
+            - development
         variables:
             %for commit in except_commit_list:
             - $CI_COMMIT_MESSAGE  =~ /${commit}/
@@ -266,6 +330,8 @@ Changed_create_plots:
         refs:
             - external_pull_requests
             ${merge_branch}
+            - master
+            - development
         variables:
             %for commit in except_commit_list:
             - $CI_COMMIT_MESSAGE  =~ /${commit}/
@@ -348,6 +414,8 @@ RegressionTest_Check_References:
     except:
         refs:
             ${merge_branch}
+            - master
+            - development
         variables:
             %for commit in except_commit_list:
             - $CI_COMMIT_MESSAGE  =~ /${commit}/

--- a/bin/templates/03_ci_templates/02_UnitTests/simulate_model.gitlab-ci.yml
+++ b/bin/templates/03_ci_templates/02_UnitTests/simulate_model.gitlab-ci.yml
@@ -72,7 +72,92 @@ CI_simulate_AixLib_Utilities:
     extends: .CI_simulate_model_job
 
     
-    
+.dev_simulate_model_job:
+    stage: simulate
+    before_script:
+        - export PIP_CACHE_DIR="/opt/cache/pip"
+        - source activate myenv
+        - pip install natsort
+        - export PYTHONIOENCODING=utf-8 # just in case
+    script:
+        - xvfb-run -n 77 python bin/CITests/02_UnitTests/CheckPackages/validatetest.py  --single-package "${lib_package}" --library AixLib -DS 2022 --wh-library IBPSA --filterwhitelist --simulateexamples
+    artifacts:
+        when: on_failure
+        paths:
+            - AixLib/AixLib.${lib_package}-log.txt
+            - AixLib/AixLib.${lib_package}-errorlog.txt
+        expire_in: 7 day
+    only:
+        refs:
+            - master
+            - development
+    except:
+        variables:
+            - $CI_COMMIT_MESSAGE  =~ /ci_update_ref/
+            - $CI_COMMIT_MESSAGE  =~ /ci_dif_ref/
+            - $CI_COMMIT_MESSAGE  =~ /ci_correct_html/
+            - $CI_COMMIT_MESSAGE  =~ /ci_create_whitelist/
+            - $CI_COMMIT_MESSAGE  =~ /Automatic push of CI with new regression reference files. Please pull the new files before push again./
+            - $CI_COMMIT_MESSAGE  =~ /New reference files were pushed to this branch. The job was successfully and the newly added files are tested in another commit./
+            - $CI_COMMIT_MESSAGE  =~ /ci_show_ref/
+            - $CI_COMMIT_MESSAGE  =~ /ci_regression_test/
+            - $CI_COMMIT_MESSAGE  =~ /ci_check/
+            - $CI_COMMIT_MESSAGE  =~ /ci_simulate/
+            - $CI_COMMIT_MESSAGE  =~ /ci_create_html_whitelist/
+            - $CI_COMMIT_MESSAGE  =~ /ci_html/
+            - $CI_COMMIT_MESSAGE  =~ /ci_setting/
+    retry:
+        max: 2
+        when: runner_system_failure
+
+Development_simulate_AixLib_Airflow:
+    variables:
+        lib_package: Airflow
+    extends: .dev_simulate_model_job
+
+Development_simulate_AixLib_BoundaryConditions:
+    variables:
+        lib_package: BoundaryConditions
+    extends: .dev_simulate_model_job
+
+Development_simulate_AixLib_Controls:
+    variables:
+        lib_package: Controls
+    extends: .dev_simulate_model_job
+
+Development_simulate_AixLib_Electrical:
+    variables:
+        lib_package: Electrical
+    extends: .dev_simulate_model_job
+
+Development_simulate_AixLib_Fluid:
+    variables:
+        lib_package: Fluid
+    extends: .dev_simulate_model_job
+
+Development_simulate_AixLib_Media:
+    variables:
+        lib_package: Media
+    extends: .dev_simulate_model_job
+
+Development_simulate_AixLib_Systems:
+    variables:
+        lib_package: Systems
+    extends: .dev_simulate_model_job
+
+Development_simulate_AixLib_ThermalZones:
+    variables:
+        lib_package: ThermalZones
+    extends: .dev_simulate_model_job
+
+Development_simulate_AixLib_Utilities:
+    variables:
+        lib_package: Utilities
+    extends: .dev_simulate_model_job
+
+
+
+
 .simulate_model_job:
     stage: simulate
     before_script:
@@ -91,6 +176,7 @@ CI_simulate_AixLib_Utilities:
     only:
         refs:
             - external_pull_requests
+
     except:
         variables:
             - $CI_COMMIT_MESSAGE  =~ /ci_update_ref/
@@ -106,6 +192,10 @@ CI_simulate_AixLib_Utilities:
             - $CI_COMMIT_MESSAGE  =~ /ci_create_html_whitelist/
             - $CI_COMMIT_MESSAGE  =~ /ci_html/
             - $CI_COMMIT_MESSAGE  =~ /ci_setting/
+        refs:
+            - master
+            - development
+
     retry:
         max: 2
         when: runner_system_failure  
@@ -176,6 +266,8 @@ simulate_AixLib_Utilities:
         refs:
             - external_pull_requests
             - IBPSA_Merge
+            - master
+            - development
         variables:
             - $CI_COMMIT_MESSAGE  =~ /ci_update_ref/
             - $CI_COMMIT_MESSAGE  =~ /ci_dif_ref/

--- a/bin/templates/03_ci_templates/02_UnitTests/simulate_model.txt
+++ b/bin/templates/03_ci_templates/02_UnitTests/simulate_model.txt
@@ -34,7 +34,44 @@ CI_simulate_${library}_${package}:
 
 %endfor
     
-    
+.dev_simulate_model_job:
+    stage: simulate
+    before_script:
+        - export PIP_CACHE_DIR="/opt/cache/pip"
+        - source activate ${python_version}
+        - pip install natsort
+        - export PYTHONIOENCODING=utf-8 # just in case
+    script:
+        - xvfb-run -n 77 python bin/CITests/02_UnitTests/CheckPackages/validatetest.py  --single-package "${lib_package}" --library ${library} -DS ${dymolaversion} ${wh_flag} ${filterflag} --simulateexamples
+    artifacts:
+        when: on_failure
+        paths:
+            - ${library}/${library}.${lib_package}-log.txt
+            - ${library}/${library}.${lib_package}-errorlog.txt
+        expire_in: 7 day
+    only:
+        refs:
+            - master
+            - development
+    except:
+        variables:
+            %for commit in except_commit_list:
+            - $CI_COMMIT_MESSAGE  =~ /${commit}/
+            %endfor
+    retry:
+        max: 2
+        when: runner_system_failure
+
+%for package in package_list:
+Development_simulate_${library}_${package}:
+    variables:
+        lib_package: ${package}
+    extends: .dev_simulate_model_job
+
+%endfor
+
+
+
 .simulate_model_job:
     stage: simulate
     before_script:
@@ -53,11 +90,16 @@ CI_simulate_${library}_${package}:
     only:
         refs:
             - external_pull_requests
+
     except:
         variables:
             %for commit in except_commit_list:
             - $CI_COMMIT_MESSAGE  =~ /${commit}/
             %endfor
+        refs:
+            - master
+            - development
+
     retry:
         max: 2
         when: runner_system_failure  
@@ -90,6 +132,8 @@ simulate_${library}_${package}:
         refs:
             - external_pull_requests
             ${merge_branch}
+            - master
+            - development
         variables:
             %for commit in except_commit_list:
             - $CI_COMMIT_MESSAGE  =~ /${commit}/

--- a/bin/templates/03_ci_templates/03_SyntaxTest/html_check.gitlab-ci.yml
+++ b/bin/templates/03_ci_templates/03_SyntaxTest/html_check.gitlab-ci.yml
@@ -58,6 +58,7 @@ HTML_Merge_Checks:
     only:
         refs:
             - external_pull_requests
+
     except:
         variables:
             - $CI_COMMIT_MESSAGE  =~ /ci_update_ref/
@@ -73,6 +74,9 @@ HTML_Merge_Checks:
             - $CI_COMMIT_MESSAGE  =~ /ci_create_html_whitelist/
             - $CI_COMMIT_MESSAGE  =~ /ci_html/
             - $CI_COMMIT_MESSAGE  =~ /ci_setting/
+        refs:
+            - master
+            - development
   
 HTML_Check:
     stage: HTML_Check
@@ -117,7 +121,7 @@ HTML_Check:
         refs:
             - external_pull_requests
             - /^Correct_HTML.*$/
-            - IBPSA_Merge 
+            - IBPSA_Merge
         variables:
             - $CI_COMMIT_MESSAGE  =~ /ci_update_ref/
             - $CI_COMMIT_MESSAGE  =~ /ci_dif_ref/

--- a/bin/templates/03_ci_templates/03_SyntaxTest/html_check.txt
+++ b/bin/templates/03_ci_templates/03_SyntaxTest/html_check.txt
@@ -58,11 +58,15 @@ HTML_Merge_Checks:
     only:
         refs:
             - external_pull_requests
+
     except:
         variables:
             %for commit in except_commit_list:
             - $CI_COMMIT_MESSAGE  =~ /${commit}/
             %endfor
+        refs:
+            - master
+            - development
   
 HTML_Check:
     stage: HTML_Check
@@ -107,7 +111,7 @@ HTML_Check:
         refs:
             - external_pull_requests
             - /^Correct_HTML.*$/
-            ${merge_branch} 
+            ${merge_branch}
         variables:
             %for commit in except_commit_list:
             - $CI_COMMIT_MESSAGE  =~ /${commit}/

--- a/bin/templates/03_ci_templates/03_SyntaxTest/style_check.gitlab-ci.yml
+++ b/bin/templates/03_ci_templates/03_SyntaxTest/style_check.gitlab-ci.yml
@@ -19,6 +19,7 @@ Style_Check_AixLib:
     only:
         refs:
             - external_pull_requests
+
     except:
         variables:
             - $CI_COMMIT_MESSAGE  =~ /ci_update_ref/
@@ -34,7 +35,31 @@ Style_Check_AixLib:
             - $CI_COMMIT_MESSAGE  =~ /ci_create_html_whitelist/
             - $CI_COMMIT_MESSAGE  =~ /ci_html/
             - $CI_COMMIT_MESSAGE  =~ /ci_setting/
-            
+        refs:
+            - master
+            - development
+
+
+Development_Style_Check:
+    stage: StyleCheck
+    before_script:
+        - export PIP_CACHE_DIR="/opt/cache/pip"
+        - source activate myenv
+        - export PYTHONIOENCODING=utf-8 # just in case
+    script:
+        - xvfb-run -n 77 python bin/CITests/03_SyntaxTests/StyleChecking.py -s AixLib -p AixLib/package.mo -DS 2022
+    artifacts:
+        when: on_failure
+        paths:
+            - AixLib/AixLib_StyleCheckLog.html
+            - AixLib/AixLib_StyleErrorLog.html
+        expire_in: 7 day
+    allow_failure: true
+    only:
+        refs:
+            - master
+            - development
+
     
 Style_Check_ChangedModel:
     stage: StyleCheck
@@ -52,7 +77,9 @@ Style_Check_ChangedModel:
     except:
         refs:
             - external_pull_requests
-            - IBPSA_Merge 
+            - IBPSA_Merge
+            - master
+            - development
         variables:
             - $CI_COMMIT_MESSAGE =~ /ci_update_ref/
             - $CI_COMMIT_MESSAGE =~ /ci_dif_ref/

--- a/bin/templates/03_ci_templates/03_SyntaxTest/style_check.txt
+++ b/bin/templates/03_ci_templates/03_SyntaxTest/style_check.txt
@@ -19,12 +19,37 @@ Style_Check_AixLib:
     only:
         refs:
             - external_pull_requests
+
     except:
         variables:
             %for commit in except_commit_list:
             - $CI_COMMIT_MESSAGE  =~ /${commit}/
             %endfor
-            
+        refs:
+            - master
+            - development
+
+
+Development_Style_Check:
+    stage: StyleCheck
+    before_script:
+        - export PIP_CACHE_DIR="/opt/cache/pip"
+        - source activate ${python_version}
+        - export PYTHONIOENCODING=utf-8 # just in case
+    script:
+        - xvfb-run -n 77 python bin/CITests/03_SyntaxTests/StyleChecking.py -s ${library} -p ${library}/package.mo -DS ${dymolaversion}
+    artifacts:
+        when: on_failure
+        paths:
+            - ${library}/${library}_StyleCheckLog.html
+            - ${library}/${library}_StyleErrorLog.html
+        expire_in: 7 day
+    allow_failure: true
+    only:
+        refs:
+            - master
+            - development
+
     
 Style_Check_ChangedModel:
     stage: StyleCheck
@@ -42,7 +67,9 @@ Style_Check_ChangedModel:
     except:
         refs:
             - external_pull_requests
-            ${merge_branch} 
+            ${merge_branch}
+            - master
+            - development
         variables:
             %for commit in except_commit_list:
             - $CI_COMMIT_MESSAGE =~ /${commit}/


### PR DESCRIPTION
Wrong commands in the Conversion scripts:
Change convertClass("AixLib.Airflow.Multizone.MediumColumnDynamic", {"massDynamics"}, fill("",0), true); to ConvertModifiers ("AixLib.Airflow.Multizone.MediumColumnDynamic", {"massDynamics"}, fill("",0), true);

- ConvertAixLib_from_1.0.3_to_1.1.0.mos: line 9 - 38
- ConvertAixLib_from_1.2.0_to_1.2.1.mos: line 5 
- Issue #1310 