### PR TITLE
Fix partialMedium by using si units

### DIFF
--- a/AixLib/Fluid/BoilerCHP/BaseClasses/PartialHeatGenerator.mo
+++ b/AixLib/Fluid/BoilerCHP/BaseClasses/PartialHeatGenerator.mo
@@ -20,13 +20,13 @@ partial model PartialHeatGenerator "Partial model for heat generators"
   parameter Modelica.Units.SI.Time tauHeaTra=1200
     "Time constant for heat transfer, default 20 minutes"
     annotation (Dialog(tab="Advanced", group="Sensor Properties"));
-  parameter Modelica.Media.Interfaces.Types.AbsolutePressure dp_start=0
+  parameter Modelica.Units.SI.AbsolutePressure dp_start=0
     "Guess value of dp = port_a.p - port_b.p"
     annotation (Dialog(tab="Advanced", group="Initialization"));
-  parameter Modelica.Media.Interfaces.PartialMedium.MassFlowRate m_flow_start=0
+  parameter Modelica.Units.SI.MassFlowRate m_flow_start=0
     "Guess value of m_flow = port_a.m_flow"
     annotation (Dialog(tab="Advanced", group="Initialization"));
-  parameter Modelica.Media.Interfaces.Types.AbsolutePressure p_start=Medium.p_default
+  parameter Modelica.Units.SI.AbsolutePressure p_start=Medium.p_default
     "Start value of pressure"
     annotation (Dialog(tab="Advanced", group="Initialization"));
 

--- a/AixLib/Fluid/BoilerCHP/Examples/BoilerSystem.mo
+++ b/AixLib/Fluid/BoilerCHP/Examples/BoilerSystem.mo
@@ -6,7 +6,7 @@ model BoilerSystem "Example that illustrates use of boiler model"
     use_m_flow_in=false,
     nPorts=1,
     redeclare package Medium =
-        Media.Specialized.Water.TemperatureDependentDensity,
+        AixLib.Media.Specialized.Water.TemperatureDependentDensity,
     m_flow=0.05,
     T=293.15)
     "Source"
@@ -15,7 +15,7 @@ model BoilerSystem "Example that illustrates use of boiler model"
     length=1,
     diameter=0.025,
     redeclare package Medium =
-        Media.Specialized.Water.TemperatureDependentDensity)
+        AixLib.Media.Specialized.Water.TemperatureDependentDensity)
     "Pressure drop"
     annotation (Placement(transformation(extent={{30,-10},{50,10}})));
   inner Modelica.Fluid.System system(p_start=system.p_ambient,
@@ -24,7 +24,7 @@ model BoilerSystem "Example that illustrates use of boiler model"
     annotation (Placement(transformation(extent={{80,80},{100,100}})));
   Boiler boiler(
     redeclare package Medium =
-        Media.Specialized.Water.TemperatureDependentDensity,
+        AixLib.Media.Specialized.Water.TemperatureDependentDensity,
     m_flow_nominal=0.03,
     redeclare model ExtControl =
         BaseClasses.Controllers.ExternalControlNightDayHC,
@@ -37,7 +37,7 @@ model BoilerSystem "Example that illustrates use of boiler model"
     "Boiler"
     annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
   Modelica.Fluid.Sources.Boundary_pT sink(nPorts=1, redeclare package Medium =
-    Media.Specialized.Water.TemperatureDependentDensity)
+    AixLib.Media.Specialized.Water.TemperatureDependentDensity)
     "Sink"
     annotation (Placement(transformation(extent={{80,-10},{60,10}})));
   Modelica.Blocks.Sources.BooleanConstant on

--- a/AixLib/Fluid/BoilerCHP/Examples/ModularCHPSystem.mo
+++ b/AixLib/Fluid/BoilerCHP/Examples/ModularCHPSystem.mo
@@ -101,11 +101,11 @@ model ModularCHPSystem
     annotation (Dialog(tab="Advanced", group="Assumptions"));
   parameter Boolean VolCon=true  "Is volume flow rate control used?"
     annotation (Dialog(tab="Engine Cooling Circle"));
-  parameter Modelica.Media.Interfaces.PartialMedium.MassFlowRate
+  parameter Modelica.Units.SI.MassFlowRate
     mExh_flow_small=0.001
     "Small exhaust mass flow rate for regularization of zero flow"
     annotation (Dialog(tab="Advanced", group="Assumptions"));
-  parameter Modelica.Media.Interfaces.PartialMedium.MassFlowRate
+  parameter Modelica.Units.SI.MassFlowRate
     mCool_flow_small=0.005
     "Small coolant mass flow rate for regularization of zero flow"
     annotation (Dialog(tab="Advanced", group="Assumptions"));

--- a/AixLib/Fluid/BoilerCHP/ModularCHP/BaseClasses/ExhaustHeatExchanger.mo
+++ b/AixLib/Fluid/BoilerCHP/ModularCHP/BaseClasses/ExhaustHeatExchanger.mo
@@ -79,7 +79,7 @@ model ExhaustHeatExchanger
   parameter Modelica.Units.SI.Time tauHeaTra=1200
     "Time constant for heat transfer, default 20 minutes"
     annotation (Dialog(tab="Advanced", group="Sensor Properties"));
-  parameter Modelica.Media.Interfaces.PartialMedium.MassFlowRate m_flow_start=0
+  parameter Modelica.Units.SI.MassFlowRate m_flow_start=0
     "Guess value of m_flow = port_a.m_flow"
     annotation (Dialog(tab="Advanced", group="Initialization"));
   constant Modelica.Units.SI.MolarMass M_H2O=0.01802 "Molar mass of water";
@@ -254,8 +254,6 @@ model ExhaustHeatExchanger
     final allowFlowReversal=allowFlowReversal1,
     final m_flow_nominal=m1_flow_nominal,
     dh=d_iExh,
-    rho_default=1.18,
-    mu_default=1.82*10^(-5),
     length=l_ExhHex) "Pressure drop of the exhaust gas"
     annotation (Placement(transformation(extent={{0,50},{20,70}})));
   AixLib.Utilities.HeatTransfer.HeatConvPipeInsideDynamic

--- a/AixLib/Fluid/BoilerCHP/ModularCHP/BaseClasses/ModularCHP_PowerUnit.mo
+++ b/AixLib/Fluid/BoilerCHP/ModularCHP/BaseClasses/ModularCHP_PowerUnit.mo
@@ -68,7 +68,7 @@ model ModularCHP_PowerUnit "Model of modular CHP power unit"
   parameter Modelica.Units.SI.Area A_surExhHea=50
     "Surface for exhaust heat transfer" annotation (Dialog(tab=
           "Calibration parameters", group="Advanced calibration parameters"));
-  parameter Modelica.Media.Interfaces.PartialMedium.MassFlowRate m_flow=
+  parameter Modelica.Units.SI.MassFlowRate m_flow=
       CHPEngineModel.m_floCooNominal
     "Nominal mass flow rate of coolant inside the engine cooling circle" annotation (Dialog(tab=
           "Calibration parameters", group="Advanced calibration parameters"));
@@ -84,11 +84,11 @@ model ModularCHP_PowerUnit "Model of modular CHP power unit"
   parameter Boolean allowFlowReversalCoolant=true
     "= false to simplify equations, assuming, but not enforcing, no flow reversal for coolant medium"
     annotation (Dialog(tab="Advanced", group="Assumptions"));
-  parameter Modelica.Media.Interfaces.PartialMedium.MassFlowRate
+  parameter Modelica.Units.SI.MassFlowRate
     mExh_flow_small=0.0001
     "Small exhaust mass flow rate for regularization of zero flow"
     annotation (Dialog(tab="Advanced", group="Assumptions"));
-  parameter Modelica.Media.Interfaces.PartialMedium.MassFlowRate
+  parameter Modelica.Units.SI.MassFlowRate
     mCool_flow_small=0.0001
     "Small coolant mass flow rate for regularization of zero flow"
     annotation (Dialog(tab="Advanced", group="Assumptions"));

--- a/AixLib/Fluid/BoilerCHP/ModularCHP/BaseClasses/SubmodelCooling.mo
+++ b/AixLib/Fluid/BoilerCHP/ModularCHP/BaseClasses/SubmodelCooling.mo
@@ -10,7 +10,7 @@ model SubmodelCooling
     CHPEngineModel=DataBase.CHP.ModularCHPEngineData.CHP_ECPowerXRGI15()
     "CHP engine data for calculations"
     annotation (choicesAllMatching=true, Dialog(group="Unit properties"));
-  parameter Modelica.Media.Interfaces.PartialMedium.MassFlowRate m_flow=
+  parameter Modelica.Units.SI.MassFlowRate m_flow=
       CHPEngineModel.m_floCooNominal
     "Nominal mass flow rate of coolant inside the engine cooling circle" annotation (Dialog(tab="Engine Cooling Circle"));
   parameter Modelica.Units.SI.ThermalConductance GEngToCoo=45
@@ -20,7 +20,7 @@ model SubmodelCooling
   parameter Boolean allowFlowReversalCoolant=true
     "= false to simplify equations, assuming, but not enforcing, no flow reversal for coolant medium"
     annotation (Dialog(tab="Advanced", group="Assumptions"));
-  parameter Modelica.Media.Interfaces.PartialMedium.MassFlowRate
+  parameter Modelica.Units.SI.MassFlowRate
     mCool_flow_small=0.0001
     "Small coolant mass flow rate for regularization of zero flow"
     annotation (Dialog(tab="Advanced", group="Assumptions"));

--- a/AixLib/Fluid/BoilerCHP/ModularCHP/ModularCHPIntegrated.mo
+++ b/AixLib/Fluid/BoilerCHP/ModularCHP/ModularCHPIntegrated.mo
@@ -95,11 +95,11 @@ model ModularCHPIntegrated
   parameter Boolean allowFlowReversalCoolant=true
     "= false to simplify equations, assuming, but not enforcing, no flow reversal for coolant medium"
     annotation (Dialog(tab="Advanced", group="Assumptions"));
-  parameter Modelica.Media.Interfaces.PartialMedium.MassFlowRate
+  parameter Modelica.Units.SI.MassFlowRate
     mExh_flow_small=0.001
     "Small exhaust mass flow rate for regularization of zero flow"
     annotation (Dialog(tab="Advanced", group="Assumptions"));
-  parameter Modelica.Media.Interfaces.PartialMedium.MassFlowRate
+  parameter Modelica.Units.SI.MassFlowRate
     mCool_flow_small=0.005
     "Small coolant mass flow rate for regularization of zero flow"
     annotation (Dialog(tab="Advanced", group="Assumptions"));


### PR DESCRIPTION
Closes #1338 .

The `ModularCHPSystem` still does not simulate, as multiple errors in the custom Media exist. However, we should keep this as a separate issue.