### PR TITLE
Fix missing each #1342

### DIFF
--- a/AixLib/DataBase/ThermalZones/ZoneBaseRecord.mo
+++ b/AixLib/DataBase/ThermalZones/ZoneBaseRecord.mo
@@ -127,7 +127,7 @@ record ZoneBaseRecord "Base record definition for zone records"
   parameter Real maxAHU(unit = "m3/(h.m2)")
     "Maximum specific air flow supplied by the AHU";
   parameter Real shadingFactor[nOrientations] "Fc-Value: Factor representing how much of the actual solar irradiation goes through the sunblind and enters the window element, for the case, that the sunblind is activated. Defaults to 1, i.e. no shading is active. External sunblinds.";
-  parameter Real maxIrr[nOrientations](unit = "W/m2") "Threshold value above which the sunblind (external) becomes active for the whole zone. Threshold regards to the incoming irradiation level with the window direction. This value does not account for heat flux due to the outside temperature.";
+  parameter Real maxIrr[nOrientations](each unit = "W/m2") "Threshold value above which the sunblind (external) becomes active for the whole zone. Threshold regards to the incoming irradiation level with the window direction. This value does not account for heat flux due to the outside temperature.";
   parameter Real hHeat "Upper limit controller output";
   parameter Real lHeat "Lower limit controller output";
   parameter Real KRHeat "Gain of the controller";


### PR DESCRIPTION
This PR already enables the simulation of `ThermalZone` in OpenModelica. At a first glance, the results are almost the same. 
However, we should keep #1349 open as further issues exist. I will update the OM error logs based on this PR.

Closes #1342. 