### PR TITLE
Add interval length to make simulation run in OM #1341

### DIFF
--- a/AixLib/Electrical/PVSystem/Examples/ExamplePVSystem.mo
+++ b/AixLib/Electrical/PVSystem/Examples/ExamplePVSystem.mo
@@ -45,7 +45,11 @@ equation
       points={{-80,0},{-34,0},{-34,0.72},{-10.16,0.72}},
       color={255,204,51},
       thickness=0.5));
-  annotation (experiment(StopTime=31536000, Tolerance=1e-06, Algorithm="dassl"),
+  annotation (experiment(
+      StopTime=31536000,
+      Interval=3600,
+      Tolerance=1e-06,
+      __Dymola_Algorithm="Dassl"),
   __Dymola_Commands(file="modelica://AixLib/Resources/Scripts/Dymola/Electrical/Examples/ExamplePVSystem.mos" "Simulate and plot"),
   Documentation(info="<html><p>
   Simulation to test the <a href=


### PR DESCRIPTION
This closes #1341.
The model AixLib.Electrical.PVSystem.Examples.ExamplePVSystem was not running in OM.
If you put the interval length of 3600 seconds as part of the experiment, it runs.
This is also an interval that I would choose for that example because weather files have a 1-hour resolution, as well.

