### PR TITLE
1361 dpcontrolledmovers fail in open modelica

### DIFF
--- a/AixLib/Fluid/Movers/DpControlledMovers/DpControlled_dp.mo
+++ b/AixLib/Fluid/Movers/DpControlledMovers/DpControlled_dp.mo
@@ -100,7 +100,7 @@ model DpControlled_dp "Pump or fan including pressure control (constant or varia
   Modelica.Blocks.Interfaces.RealInput dpMea(
     final quantity="PressureDifference",
     final displayUnit="Pa",
-    final unit="Pa")=gain.u if prescribeSystemPressure
+    final unit="Pa") if prescribeSystemPressure
     "Measurement of pressure difference between two points where the set point should be obtained"
     annotation (Placement(transformation(
         extent={{20,-20},{-20,20}},

--- a/AixLib/Fluid/Movers/DpControlledMovers/package.mo
+++ b/AixLib/Fluid/Movers/DpControlledMovers/package.mo
@@ -1,3 +1,4 @@
 within AixLib.Fluid.Movers;
 package DpControlledMovers
+extends Modelica.Icons.Package;
 end DpControlledMovers;


### PR DESCRIPTION
Error fixed as described in #1361. 
Further the modelica standard package icon is implemented to be displayed in open modelica.