### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.mo linguist-language=Modelica


### PR DESCRIPTION
With the added[ .gitattributes](https://github.com/RWTH-EBC/AixLib/blob/1383-wrong-program-languages/.gitattributes) the Motoko language should not be displayed anymore in our used Program Languages.

As linguist only looks into the default branch we will see the results after merging into development.

To prove that it works I ran linguist locally, but locally it always detects .mo as Modelica. So let's hope for the best:

Before:
```
94.70%  15697520   Modelica
2.39%   396027     Python
1.46%   242400     C
0.67%   111408     HTML
0.26%   43643      CSS
0.22%   37254      JavaScript
0.09%   14241      Java
0.05%   9067       TeX
0.05%   7489       Shell
0.05%   7486       Batchfile
0.04%   6302       Makefile
0.02%   3966       C++
```

After:
```
PS D:\02_Git\linguist> docker run --rm -v D:/02_Git/AixLib/:/AixLib -w /AixLib -t linguist github-linguist
94.70%  15697520   Modelica
2.39%   396027     Python
1.46%   242400     C
0.67%   111408     HTML
0.26%   43643      CSS
0.22%   37254      JavaScript
0.09%   14241      Java
0.05%   9067       TeX
0.05%   7489       Shell
0.05%   7486       Batchfile
0.04%   6302       Makefile
0.02%   3966       C++
```

closes #1383 