### PR TITLE
fix typo and remove experiment setup as the model is partial

### DIFF
--- a/AixLib/ThermalZones/HighOrder/Validation/ASHRAE140/BaseClasses/PartialCase.mo
+++ b/AixLib/ThermalZones/HighOrder/Validation/ASHRAE140/BaseClasses/PartialCase.mo
@@ -49,7 +49,7 @@ partial model PartialCase "This is the base class from which the base cases will
           Win_Area=Win_Area,
           absInnerWallSurf=absInnerWallSurf)
         "Room with south facing window"),
-        choice(redeclare model Room = Rooms.ASHRAE140.EathWestFacingWindows (
+        choice(redeclare model Room = Rooms.ASHRAE140.EastWestFacingWindows (
           wallTypes=wallTypes,
           calcMethodIn=4,
           Type_Win=windowParam,
@@ -223,8 +223,10 @@ equation
   connect(ReferenceCoolingLoadOrTempMin.y[1], checkResultsAccordingToASHRAECoolingOrTempMin.lowerLimit) annotation (Line(points={{72.7,-77},{86,-77},{86,-83.5},{97.95,-83.5}}, color={0,0,127}));
   connect(ReferenceCoolingLoadOrTempMin.y[2], checkResultsAccordingToASHRAECoolingOrTempMin.upperLimit) annotation (Line(points={{72.7,-77},{87,-77},{87,-80.5},{97.95,-80.5}}, color={0,0,127}));
   connect(to_degCRoomConvTemp.y, FreeFloatRoomTemperature) annotation (Line(points={{102.5,36},{140,36}}, color={0,0,127}));
-  connect(temperatureSensor.T, to_degCRoomConvTemp.u) annotation (Line(points={{84,36},{91,36}}, color={0,0,127}));
-  connect(temperatureSensor1.T, to_degCRoomConvTemp1.u) annotation (Line(points={{84,18},{91,18}}, color={0,0,127}));
+  connect(temperatureSensor.T, to_degCRoomConvTemp.u) annotation (Line(points={{84.6,36},
+          {91,36}},                                                                              color={0,0,127}));
+  connect(temperatureSensor1.T, to_degCRoomConvTemp1.u) annotation (Line(points={{84.6,18},
+          {91,18}},                                                                                color={0,0,127}));
   connect(to_degCRoomConvTemp1.y, FreeFloatRoomRadTemperature) annotation (Line(points={{102.5,18},{140,18}}, color={0,0,127}));
   connect(Room.thermRoom, temperatureSensor.port) annotation (Line(points={{-2.92,35},{-2.92,44},{67,44},{67,36},{72,36}}, color={191,0,0}));
   connect(Room.starRoom, temperatureSensor1.port) annotation (Line(points={{5.48,35},{5.48,42},{65,42},{65,18},{72,18}}, color={0,0,0}));
@@ -329,7 +331,6 @@ equation
         extent={{-150,-110},{130,90}},
         preserveAspectRatio=false,
         grid={1,1})),
-    experiment(Tolerance=1e-6, StopTime=31539600),
     __Dymola_experimentSetupOutput(events=true),
     Documentation(revisions="<html><ul>
   <li>July 1, 2020, by Konstantina Xanthopoulou:<br/>

--- a/AixLib/ThermalZones/HighOrder/Validation/ASHRAE140/BaseClasses/PartialCase.mo
+++ b/AixLib/ThermalZones/HighOrder/Validation/ASHRAE140/BaseClasses/PartialCase.mo
@@ -224,9 +224,9 @@ equation
   connect(ReferenceCoolingLoadOrTempMin.y[2], checkResultsAccordingToASHRAECoolingOrTempMin.upperLimit) annotation (Line(points={{72.7,-77},{87,-77},{87,-80.5},{97.95,-80.5}}, color={0,0,127}));
   connect(to_degCRoomConvTemp.y, FreeFloatRoomTemperature) annotation (Line(points={{102.5,36},{140,36}}, color={0,0,127}));
   connect(temperatureSensor.T, to_degCRoomConvTemp.u) annotation (Line(points={{84.6,36},
-          {91,36}},                                                                              color={0,0,127}));
+          {91,36}}, color={0,0,127}));
   connect(temperatureSensor1.T, to_degCRoomConvTemp1.u) annotation (Line(points={{84.6,18},
-          {91,18}},                                                                                color={0,0,127}));
+          {91,18}}, color={0,0,127}));
   connect(to_degCRoomConvTemp1.y, FreeFloatRoomRadTemperature) annotation (Line(points={{102.5,18},{140,18}}, color={0,0,127}));
   connect(Room.thermRoom, temperatureSensor.port) annotation (Line(points={{-2.92,35},{-2.92,44},{67,44},{67,36},{72,36}}, color={191,0,0}));
   connect(Room.starRoom, temperatureSensor1.port) annotation (Line(points={{5.48,35},{5.48,42},{65,42},{65,18},{72,18}}, color={0,0,0}));


### PR DESCRIPTION
Closes #1427.

Besides the issue itself, I removed the experiment setup as this leads to an error in OM CI (all models with experiments are checked). Such a partial case should not contain the setup anyways.