### PR TITLE
SpawnOfEnergyPlus support for bim2sim

### DIFF
--- a/AixLib/ThermalZones/HighOrder/SpawnOfEP/Multizone.mo
+++ b/AixLib/ThermalZones/HighOrder/SpawnOfEP/Multizone.mo
@@ -3,7 +3,7 @@ model Multizone
 
   parameter Integer nZones= 1
                              "Number of zones";
-  parameter Integer nPorts=1
+  parameter Integer nPorts=0
     "Number of fluid ports (equals to 2 for one inlet and one outlet)"
     annotation (Evaluate=true,Dialog(connectorSizing=true,tab="General",group="Ports"));
   replaceable package Medium=Buildings.Media.Air
@@ -17,7 +17,7 @@ model Multizone
     zoneName=zoneNames,
     redeclare package Medium = Medium,
     use_C_flow=use_C_flow,
-    nPorts=nPorts)
+    each nPorts=nPorts)
     annotation (Placement(transformation(extent={{-20,-20},{20,20}})));
   Modelica.Thermal.HeatTransfer.Sensors.TemperatureSensor temAir[nZones]
     "Air temperature sensor"
@@ -31,7 +31,7 @@ model Multizone
     annotation (Placement(transformation(extent={{-120,-20},{-80,20}})));
   Modelica.Fluid.Vessels.BaseClasses.VesselFluidPorts_b portsExt[nZones,nPorts](
      redeclare each package Medium = Medium) "Fluid inlets and outlets"
-    annotation (Placement(transformation(
+    annotation (Dialog(connectorSizing=true),Placement(transformation(
         extent={{40,-10},{-40,10}},
         rotation=180,
         origin={2,-94}), iconTransformation(

--- a/AixLib/ThermalZones/HighOrder/SpawnOfEP/Multizone.mo
+++ b/AixLib/ThermalZones/HighOrder/SpawnOfEP/Multizone.mo
@@ -1,0 +1,56 @@
+within AixLib.ThermalZones.HighOrder.SpawnOfEP;
+model Multizone
+
+  parameter Integer nZones= 1
+                             "Number of zones";
+  parameter Integer nPorts=0
+    "Number of fluid ports (equals to 2 for one inlet and one outlet)"
+    annotation (Evaluate=true,Dialog(connectorSizing=true,tab="General",group="Ports"));
+  replaceable package Medium=Buildings.Media.Air
+    "Medium model";
+  Buildings.ThermalZones.EnergyPlus_9_6_0.ThermalZone zon[nZones](
+    zoneName=zoneNames,
+    redeclare package Medium = Medium,
+    use_C_flow=use_C_flow,
+    nPorts=nPorts)
+    annotation (Placement(transformation(extent={{-20,-20},{20,20}})));
+  Modelica.Thermal.HeatTransfer.Sensors.TemperatureSensor temAir[nZones]
+    "Air temperature sensor"
+    annotation (Placement(transformation(extent={{64,-10},{84,10}})));
+  Modelica.Blocks.Interfaces.RealOutput TRooAir[nZones](each unit="K", each
+      displayUnit="degC") "Room air temperatures" annotation (Placement(
+        transformation(extent={{100,-10},{120,10}}), iconTransformation(extent={{100,-10},
+            {120,10}})));
+  Modelica.Blocks.Interfaces.RealInput qGai_flow[nZones,3]
+    "Radiant, convective sensible and latent heat input into room (positive if heat gain)"
+    annotation (Placement(transformation(extent={{-120,-20},{-80,20}})));
+  Modelica.Fluid.Vessels.BaseClasses.VesselFluidPorts_b portsExt[nZones](
+      redeclare each package Medium = Medium) "Fluid inlets and outlets"
+    annotation (Placement(transformation(
+        extent={{40,-10},{-40,10}},
+        rotation=180,
+        origin={2,-94}), iconTransformation(
+        extent={{40,-9},{-40,9}},
+        rotation=180,
+        origin={2,-99})));
+  Modelica.Thermal.HeatTransfer.Interfaces.HeatPort_a heaPorExt[nZones]
+    "Heat port to air volume"
+    annotation (Placement(transformation(extent={{-68,-108},{-48,-88}})));
+  parameter String zoneNames[nZones]
+    "Name of the thermal zone as specified in the EnergyPlus input";
+  parameter Boolean use_C_flow[nZones]=fill(false, nZones)
+    "Set to true to enable input connector for trace substance that is connected to room air";
+equation
+  connect(temAir.T, TRooAir)
+    annotation (Line(points={{85,0},{110,0}}, color={0,0,127}));
+  connect(zon.heaPorAir, temAir.port) annotation (Line(points={{0,0},{-6,0},{-6,
+          38},{62,38},{62,0},{64,0}}, color={191,0,0}));
+  connect(qGai_flow, zon.qGai_flow) annotation (Line(points={{-100,0},{-60,0},{-60,
+          10},{-22,10}}, color={0,0,127}));
+  connect(heaPorExt, zon.heaPorAir) annotation (Line(points={{-58,-98},{-58,-26},
+          {0,-26},{0,0}}, color={191,0,0}));
+  connect(portsExt, zon.ports) annotation (Line(points={{2,-94},{2,-56},{2,-19.1},
+          {0,-19.1}}, color={0,127,255}));
+  annotation (Icon(coordinateSystem(preserveAspectRatio=false)), Diagram(
+        coordinateSystem(preserveAspectRatio=false)));
+end Multizone;

--- a/AixLib/ThermalZones/HighOrder/SpawnOfEP/Multizone.mo
+++ b/AixLib/ThermalZones/HighOrder/SpawnOfEP/Multizone.mo
@@ -3,11 +3,16 @@ model Multizone
 
   parameter Integer nZones= 1
                              "Number of zones";
-  parameter Integer nPorts=0
+  parameter Integer nPorts=1
     "Number of fluid ports (equals to 2 for one inlet and one outlet)"
     annotation (Evaluate=true,Dialog(connectorSizing=true,tab="General",group="Ports"));
   replaceable package Medium=Buildings.Media.Air
     "Medium model";
+  parameter String zoneNames[nZones]
+    "Name of the thermal zone as specified in the EnergyPlus input";
+  parameter Boolean use_C_flow[nZones]=fill(false, nZones)
+    "Set to true to enable input connector for trace substance that is connected to room air";
+
   Buildings.ThermalZones.EnergyPlus_9_6_0.ThermalZone zon[nZones](
     zoneName=zoneNames,
     redeclare package Medium = Medium,
@@ -24,8 +29,8 @@ model Multizone
   Modelica.Blocks.Interfaces.RealInput qGai_flow[nZones,3]
     "Radiant, convective sensible and latent heat input into room (positive if heat gain)"
     annotation (Placement(transformation(extent={{-120,-20},{-80,20}})));
-  Modelica.Fluid.Vessels.BaseClasses.VesselFluidPorts_b portsExt[nZones](
-      redeclare each package Medium = Medium) "Fluid inlets and outlets"
+  Modelica.Fluid.Vessels.BaseClasses.VesselFluidPorts_b portsExt[nZones,nPorts](
+     redeclare each package Medium = Medium) "Fluid inlets and outlets"
     annotation (Placement(transformation(
         extent={{40,-10},{-40,10}},
         rotation=180,
@@ -36,10 +41,7 @@ model Multizone
   Modelica.Thermal.HeatTransfer.Interfaces.HeatPort_a heaPorExt[nZones]
     "Heat port to air volume"
     annotation (Placement(transformation(extent={{-68,-108},{-48,-88}})));
-  parameter String zoneNames[nZones]
-    "Name of the thermal zone as specified in the EnergyPlus input";
-  parameter Boolean use_C_flow[nZones]=fill(false, nZones)
-    "Set to true to enable input connector for trace substance that is connected to room air";
+
 equation
   connect(temAir.T, TRooAir)
     annotation (Line(points={{85,0},{110,0}}, color={0,0,127}));
@@ -49,8 +51,10 @@ equation
           10},{-22,10}}, color={0,0,127}));
   connect(heaPorExt, zon.heaPorAir) annotation (Line(points={{-58,-98},{-58,-26},
           {0,-26},{0,0}}, color={191,0,0}));
-  connect(portsExt, zon.ports) annotation (Line(points={{2,-94},{2,-56},{2,-19.1},
-          {0,-19.1}}, color={0,127,255}));
+  for i in 1:nZones loop
+      connect(zon[i].ports[:], portsExt[i,:])
+                                             annotation (Line(points={{0,-19.1},{0,-94},{2,-94}},color={0,127,255}));
+  end for;
   annotation (Icon(coordinateSystem(preserveAspectRatio=false)), Diagram(
         coordinateSystem(preserveAspectRatio=false)));
 end Multizone;

--- a/AixLib/ThermalZones/HighOrder/SpawnOfEP/package.mo
+++ b/AixLib/ThermalZones/HighOrder/SpawnOfEP/package.mo
@@ -1,0 +1,3 @@
+within AixLib.ThermalZones.HighOrder;
+package SpawnOfEP
+end SpawnOfEP;

--- a/AixLib/ThermalZones/HighOrder/SpawnOfEP/package.order
+++ b/AixLib/ThermalZones/HighOrder/SpawnOfEP/package.order
@@ -1,0 +1,1 @@
+Multizone

--- a/AixLib/ThermalZones/HighOrder/package.order
+++ b/AixLib/ThermalZones/HighOrder/package.order
@@ -1,5 +1,6 @@
 Components
 House
 Rooms
+SpawnOfEP
 Examples
 Validation


### PR DESCRIPTION
With this PR we will bring SpawnOfEnergPlus support for bim2sim using the AixLib library to store the needed models.
See https://github.com/BIM2SIM/bim2sim 