### PR TITLE
1461 add open modelica badge

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
 include:
     project: 'EBC/EBC_all/gitlab_ci/templates'
-    ref: AixLib
+    ref: AixLib-OM-badge
     file: 'dymola-ci-tests/ci_templates/.gitlab-ci.yml'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
 include:
     project: 'EBC/EBC_all/gitlab_ci/templates'
-    ref: AixLib-OM-badge
+    ref: AixLib
     file: 'dymola-ci-tests/ci_templates/.gitlab-ci.yml'

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![E.ON EBC RWTH Aachen University](./AixLib/Resources/Images/EBC_Logo.png)
-[![OM](https://ebc.pages.rwth-aachen.de/EBC_all/github_ci/AixLib/add-open-modelica-badge-ci/badge_file/om_readyness_badge.svg)](https://ebc.pages.rwth-aachen.de/EBC_all/github_ci/AixLib/add-open-modelica-badge-ci/badge_file/om_readyness_badge.svg)
+[![OM](https://ebc.pages.rwth-aachen.de/EBC_all/github_ci/AixLib/development/badge_file/om_readyness_badge.svg)](https://ebc.pages.rwth-aachen.de/EBC_all/github_ci/AixLib/development/badge_file/om_readyness_badge.svg)
 
 # AixLib
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ![E.ON EBC RWTH Aachen University](./AixLib/Resources/Images/EBC_Logo.png)
 
+[![DOI](https://ebc.pages.rwth-aachen.de/EBC_all/github_ci/AixLib/add-open-modelica-badge-ci/badge_file/om_readyness_badge.svg)](https://ebc.pages.rwth-aachen.de/EBC_all/github_ci/AixLib/add-open-modelica-badge-ci/badge_file/om_readyness_badge.svg)
+
 # AixLib
 
 **AixLib** is a Modelica model library for building performance simulations.  

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 ![E.ON EBC RWTH Aachen University](./AixLib/Resources/Images/EBC_Logo.png)
-
-[![DOI](https://ebc.pages.rwth-aachen.de/EBC_all/github_ci/AixLib/add-open-modelica-badge-ci/badge_file/om_readyness_badge.svg)](https://ebc.pages.rwth-aachen.de/EBC_all/github_ci/AixLib/add-open-modelica-badge-ci/badge_file/om_readyness_badge.svg)
+![OM](https://ebc.pages.rwth-aachen.de/EBC_all/github_ci/AixLib/add-open-modelica-badge-ci/badge_file/om_readyness_badge.svg)
 
 # AixLib
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![E.ON EBC RWTH Aachen University](./AixLib/Resources/Images/EBC_Logo.png)
-![OM](https://ebc.pages.rwth-aachen.de/EBC_all/github_ci/AixLib/add-open-modelica-badge-ci/badge_file/om_readyness_badge.svg)
+[![OM](https://ebc.pages.rwth-aachen.de/EBC_all/github_ci/AixLib/add-open-modelica-badge-ci/badge_file/om_readyness_badge.svg)](https://ebc.pages.rwth-aachen.de/EBC_all/github_ci/AixLib/add-open-modelica-badge-ci/badge_file/om_readyness_badge.svg)
 
 # AixLib
 


### PR DESCRIPTION
Adds the OpenModelicaReadyness Badge to the readme.

This will only work, when this Pull Request https://git.rwth-aachen.de/EBC/EBC_all/gitlab_ci/templates/-/merge_requests/61/ 
is approved, and the pipeline is run one time for the development branch of the aixlib, since only then the corresponding badge .svg file is created

Closes #1461 
