### PR TITLE
Issue1460 hom moisture balance

### DIFF
--- a/AixLib/ThermalZones/HighOrder/Rooms/BaseClasses/PartialRoom.mo
+++ b/AixLib/ThermalZones/HighOrder/Rooms/BaseClasses/PartialRoom.mo
@@ -1,4 +1,4 @@
-﻿within AixLib.ThermalZones.HighOrder.Rooms.BaseClasses;
+within AixLib.ThermalZones.HighOrder.Rooms.BaseClasses;
 partial model PartialRoom "Partial model with base component that are necessary for all HOM rooms"
   extends PartialRoomParams;
   extends AixLib.Fluid.Interfaces.LumpedVolumeDeclarations(redeclare package
@@ -123,14 +123,11 @@ protected
  if use_moisture_balance
     "Converter for latent heat flow rate"
     annotation (Placement(transformation(extent={{58,-52},{46,-40}})));
-  Modelica.Blocks.Interfaces.RealOutput hum_internal
+  Modelica.Blocks.Interfaces.RealOutput hum_internal = 0  if not use_moisture_balance
     "internal humidity (used for case with no moisture balance";
-  Modelica.Blocks.Interfaces.RealOutput mWat_flow_internal
+  Modelica.Blocks.Interfaces.RealOutput mWat_flow_internal = 0 if not use_moisture_balance
     "internal mass flow rate of water vapor (used for case with no moisture balance)";
 equation
-  hum_internal = 0;
-  mWat_flow_internal = 0;
-
   connect(QLat_flow, sumQLat_flow.u[2]) annotation (Line(
       points={{-112,-56},{80,-56},{80,-36.475},{76,-36.475}},
       color={0,0,127},
@@ -144,10 +141,19 @@ equation
       points={{-4,-16},{-14,-16},{-14,-14.88},{-22.6,-14.88}},
       color={0,0,127},
       pattern=LinePattern.Dash));
-  connect(NaturalVentilation.HumIn, ventHum) annotation (Line(
-      points={{-33.4,-21},{-62,-21},{-62,-22},{-74,-22},{-74,-37},{-111,-37}},
+  if use_moisture_balance then
+    connect(NaturalVentilation.HumIn, ventHum) annotation (Line(
+        points={{-33.4,-21},{-62,-21},{-62,-22},{-74,-22},{-74,-37},{-111,-37}},
+        color={0,0,127},
+        pattern=LinePattern.Dash));
+    connect(mWat_flow.y, airload.mWat_flow) annotation (Line(
+      points={{47.6,-28},{36,-28},{36,-10},{26,-10},{26,-4},{20,-4}},
       color={0,0,127},
       pattern=LinePattern.Dash));
+  else
+    connect(NaturalVentilation.HumIn, hum_internal);
+    connect(airload.mWat_flow, mWat_flow_internal);
+  end if;
   connect(conQLat_flow.port, airload.heatPort) annotation (Line(
       points={{46,-46},{24,-46},{24,-12},{18,-12}},
       color={191,0,0},
@@ -201,13 +207,9 @@ equation
       points={{69.49,-37},{64,-37},{64,-46},{58,-46}},
       color={0,0,127},
       pattern=LinePattern.Dash));
-  connect(mWat_flow.y, airload.mWat_flow) annotation (Line(
-      points={{47.6,-28},{36,-28},{36,-10},{26,-10},{26,-4},{20,-4}},
-      color={0,0,127},
-      pattern=LinePattern.Dash));
 
-  connect(NaturalVentilation.HumIn, hum_internal);
-  connect(airload.mWat_flow, mWat_flow_internal);
+
+
     annotation (Dialog(tab="Infiltration acc. to EN 12831 (building airtightness"),
               Icon(coordinateSystem(preserveAspectRatio=false)), Diagram(coordinateSystem(preserveAspectRatio=false)),
     Documentation(revisions="<html><ul>
@@ -215,7 +217,10 @@ equation
     Model added to the AixLib library.
   </li>
   <li>February, 2022 by Fabian Wüllhorst and Martin Kremer:<br/>
-    Changed airLoad-model to mxing volume to use media model. Added possibility to analyse substance and water vapor balance (see issue <a href=\"https://github.com/RWTH-EBC/AixLib/issues/1123\">#1123</a>)
+  Changed airLoad-model to mxing volume to use media model. Added possibility to analyse substance and water vapor balance (see issue <a href=\"https://github.com/RWTH-EBC/AixLib/issues/1123\">#1123</a>)
+  </li>
+  <li>November, 2023 by Benani Zoumba:<br/>
+  Changed connections for moisture balance <a href=\"https://github.com/RWTH-EBC/AixLib/issues/1460\">#1460</a>)
 </ul>
 </html>", info="<html>
 <p>This model provides a basic configuration of an air load, a replaceable parameter set for wall paramters and air exchange models that can be used to build up individual High-Order-Models for rooms.</p>

--- a/AixLib/ThermalZones/HighOrder/Rooms/BaseClasses/PartialRoom.mo
+++ b/AixLib/ThermalZones/HighOrder/Rooms/BaseClasses/PartialRoom.mo
@@ -124,7 +124,7 @@ protected
     "Converter for latent heat flow rate"
     annotation (Placement(transformation(extent={{58,-52},{46,-40}})));
   Modelica.Blocks.Interfaces.RealOutput hum_internal = 0  if not use_moisture_balance
-    "internal humidity (used for case with no moisture balance";
+    "internal humidity (used for case with no moisture balance)";
   Modelica.Blocks.Interfaces.RealOutput mWat_flow_internal = 0 if not use_moisture_balance
     "internal mass flow rate of water vapor (used for case with no moisture balance)";
 equation


### PR DESCRIPTION
Closes issue #1460 

Connections were overdetermined when activating the moisture balance in the HOM. This fix establishes connections conditionally to prevent an overdetermination of the modell.

The attached file can be used to evaluate the issue (package name may need adjustment). Simply switch "use_moisture_balance" within the parameter window of the room.
[OneRoomTest_MoistCO2_2.txt](https://github.com/RWTH-EBC/AixLib/files/13363792/OneRoomTest_MoistCO2_2.txt)
