### PR TITLE
correct the sequence in the description of internal gains output

### DIFF
--- a/AixLib/ThermalZones/ReducedOrder/Multizone/BaseClasses/MultizonePostProcessing.mo
+++ b/AixLib/ThermalZones/ReducedOrder/Multizone/BaseClasses/MultizonePostProcessing.mo
@@ -172,17 +172,17 @@ model MultizonePostProcessing
     each final quantity="Energy",
     each final unit="J",
     each displayUnit="kWh")
-    "Heat gains based on internal gains for each zone from persons, machines, and light"
+    "Heat gains based on internal gains for each zone from from lights[1], machines[2], and persons[3]"
     annotation (Placement(transformation(extent={{100,-122},{120,-102}}),
         iconTransformation(extent={{100,-130},{120,-110}})));
   Modelica.Blocks.Interfaces.RealInput QIntGains_flow[numZones,3](each final
       quantity="HeatFlowRate", each final unit="W")
-    "Heat flow based on internal gains for each zone from persons, machines, and light"
+    "Heat flow based on internal gains for each zone from lights[1], machines[2], and persons[3]"
                                                                  annotation (
       Placement(transformation(extent={{-140,-140},{-100,-100}}),
         iconTransformation(extent={{-140,-140},{-100,-100}})));
   Modelica.Blocks.Continuous.Integrator QIntGainCalc[numZones,3]
-    "Heat gain based on internal gains for each zone from persons, machines, and light"
+    "Heat gain based on internal gains for each zone from lights[1], machines[2], and persons[3]"
     annotation (Placement(transformation(extent={{58,-124},{74,-108}})));
 equation
   connect(TAirAverageCalc.u, TAir) annotation (Line(points={{56.4,96},{56.4,100},

--- a/AixLib/ThermalZones/ReducedOrder/Multizone/BaseClasses/MultizonePostProcessing.mo
+++ b/AixLib/ThermalZones/ReducedOrder/Multizone/BaseClasses/MultizonePostProcessing.mo
@@ -172,7 +172,7 @@ model MultizonePostProcessing
     each final quantity="Energy",
     each final unit="J",
     each displayUnit="kWh")
-    "Heat gains based on internal gains for each zone from from lights[1], machines[2], and persons[3]"
+    "Heat gains based on internal gains for each zone from lights[1], machines[2], and persons[3]"
     annotation (Placement(transformation(extent={{100,-122},{120,-102}}),
         iconTransformation(extent={{100,-130},{120,-110}})));
   Modelica.Blocks.Interfaces.RealInput QIntGains_flow[numZones,3](each final

--- a/AixLib/ThermalZones/ReducedOrder/Multizone/BaseClasses/PartialMultizone.mo
+++ b/AixLib/ThermalZones/ReducedOrder/Multizone/BaseClasses/PartialMultizone.mo
@@ -155,7 +155,7 @@ partial model PartialMultizone "Partial model for multizone models"
   //Swimming pool params
   parameter Boolean use_pools_tot = false "use swimming pools within at least one zone of the multizone" annotation(Dialog(tab="Moisture", group="Pools"));
   replaceable package MediumPoolWater = Media.Water annotation (choices(choice(redeclare
-          package                                                                                Medium =
+          package Medium =
             AixLib.Media.Water
               "Water")), Dialog(enable=use_pools_tot,tab="Moisture", group="Pools"));
 
@@ -199,7 +199,7 @@ partial model PartialMultizone "Partial model for multizone models"
     extent={{80,-100},{100,-80}})));
   Modelica.Blocks.Interfaces.RealOutput QIntGains_flow[numZones,3](each final
       quantity="HeatFlowRate", each final unit="W") if ASurTot > 0 or VAir > 0
-    "Heat flow based on internal gains for each zone from persons, machines, and light"
+    "Heat flow based on internal gains from lights[1], machines[2], and persons[3]"
                         annotation (Placement(transformation(extent={{100,-90},{
             120,-70}}), iconTransformation(extent={{80,-100},{100,-80}})));
   Modelica.Blocks.Interfaces.RealInput timeOpe

--- a/AixLib/ThermalZones/ReducedOrder/Multizone/BaseClasses/PartialMultizone.mo
+++ b/AixLib/ThermalZones/ReducedOrder/Multizone/BaseClasses/PartialMultizone.mo
@@ -199,7 +199,7 @@ partial model PartialMultizone "Partial model for multizone models"
     extent={{80,-100},{100,-80}})));
   Modelica.Blocks.Interfaces.RealOutput QIntGains_flow[numZones,3](each final
       quantity="HeatFlowRate", each final unit="W") if ASurTot > 0 or VAir > 0
-    "Heat flow based on internal gains from lights[1], machines[2], and persons[3]"
+    "Heat flow based on internal gains for each zone from lights[1], machines[2], and persons[3]"
                         annotation (Placement(transformation(extent={{100,-90},{
             120,-70}}), iconTransformation(extent={{80,-100},{100,-80}})));
   Modelica.Blocks.Interfaces.RealInput timeOpe

--- a/AixLib/ThermalZones/ReducedOrder/ThermalZone/ThermalZone.mo
+++ b/AixLib/ThermalZones/ReducedOrder/ThermalZone/ThermalZone.mo
@@ -4,7 +4,8 @@ model ThermalZone "Thermal zone containing moisture balance"
     AixLib.ThermalZones.ReducedOrder.ThermalZone.BaseClasses.PartialThermalZone;
 
   replaceable model corG = SolarGain.CorrectionGDoublePane
-    constrainedby AixLib.ThermalZones.ReducedOrder.SolarGain.BaseClasses.PartialCorrectionG
+    constrainedby
+    AixLib.ThermalZones.ReducedOrder.SolarGain.BaseClasses.PartialCorrectionG
     "Model for correction of solar transmission"
     annotation(choicesAllMatching=true);
   parameter Integer internalGainsMode = 1
@@ -58,7 +59,8 @@ model ThermalZone "Thermal zone containing moisture balance"
 
   // Pool parameters
   replaceable package MediumPoolWater = AixLib.Media.Water
-   "Medium in the component"  annotation (choices(choice(redeclare package Medium =
+   "Medium in the component"  annotation (choices(choice(redeclare package
+          Medium =
             AixLib.Media.Water
               "Water")), Dialog(enable=use_pools,tab="Moisture", group="Pools"));
   parameter Integer nPools(min=1)=1  "Number of pools in thermal zone" annotation(Dialog(enable=use_pools,tab="Moisture", group="Pools"));
@@ -334,7 +336,7 @@ model ThermalZone "Thermal zone containing moisture balance"
     annotation (Placement(transformation(extent={{-84,61},{-68,77}})));
   Modelica.Blocks.Interfaces.RealOutput QIntGains_flow[3](each final quantity="HeatFlowRate",
       each final unit="W") if ATot > 0
-    "Heat flow based on internal gains from persons, machines, and light"
+    "Heat flow based on internal gains from lights[1], machines[2], and persons[3]"
                                                            annotation (
       Placement(transformation(extent={{100,-50},{120,-30}}),
         iconTransformation(extent={{100,-50},{120,-30}})));
@@ -776,8 +778,7 @@ elseif use_MechanicalAirExchange and not use_NaturalAirExchange then
               {-21.2,-10}},
       color={0,0,127},
       pattern=LinePattern.Dash));
-else
-     connect(addInfVen.y, cO2Balance.airExc) annotation (Line(points={{-29.5,-27},
+else connect(addInfVen.y, cO2Balance.airExc) annotation (Line(points={{-29.5,-27},
             {-24,-27},{-24,-34},{12,-34},{12,-63.6},{16,-63.6}},
                                                             color={0,0,127}));
      connect(addInfVen.y, airExc.ventRate) annotation (Line(points={{-29.5,-27},


### PR DESCRIPTION
This is a minor issue but it led to some annoying problems in my post processing.

Change the wrong description:
> Heat flow based on internal gains from persons, machines and lights.

into
> Heat flow based on internal gains from lights[1], machines[2], and persons[3]


closes #1481 