### PR TITLE
1525 wrong description of the incidence angle

### DIFF
--- a/AixLib/BoundaryConditions/WeatherData/Old/WeatherTRY/RadiationOnTiltedSurface/RadOnTiltedSurf_Liu.mo
+++ b/AixLib/BoundaryConditions/WeatherData/Old/WeatherTRY/RadiationOnTiltedSurface/RadOnTiltedSurf_Liu.mo
@@ -58,16 +58,17 @@ equation
 
   // calculation of total radiation on tilted surface according to model of Liu and Jordan
   // according to [Dissertation Nytsch-Geusen, p.98]
-  OutTotalRadTilted.I = max(0, R*InBeamRadHor + 0.5*(1 + cos(from_deg(
+  OutTotalRadTilted.H = max(0, R*InBeamRadHor + 0.5*(1 + cos(from_deg(
     Tilt)))*InDiffRadHor + GroundReflection*(InBeamRadHor + InDiffRadHor)
     *((1 - cos(from_deg(Tilt)))/2));
 
   // Setting the outputs of direct. diffuse and ground reflection radiation on tilted surface and the angle of incidence
-  OutTotalRadTilted.I_dir = R*InBeamRadHor;
-  OutTotalRadTilted.I_diff = 0.5*(1 + cos(from_deg(Tilt)))*InDiffRadHor;
-  OutTotalRadTilted.I_gr = GroundReflection*(InBeamRadHor + InDiffRadHor)*((1 - cos(from_deg(Tilt)))/2);
+  OutTotalRadTilted.HDir = R*InBeamRadHor;
+  OutTotalRadTilted.HDif = 0.5*(1 + cos(from_deg(Tilt)))*InDiffRadHor;
+  OutTotalRadTilted.HGrd = GroundReflection*(InBeamRadHor + InDiffRadHor)*((1 - cos(from_deg(Tilt)))/2);
 
-  OutTotalRadTilted.AOI = Modelica.Math.acos(cos_theta); // in rad
+  OutTotalRadTilted.incAng = Modelica.Math.acos(cos_theta);
+                                                         // in rad
 
   annotation (
     Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},

--- a/AixLib/BoundaryConditions/WeatherData/Old/WeatherTRY/RadiationOnTiltedSurface/RadOnTiltedSurf_Perez.mo
+++ b/AixLib/BoundaryConditions/WeatherData/Old/WeatherTRY/RadiationOnTiltedSurface/RadOnTiltedSurf_Perez.mo
@@ -255,14 +255,15 @@ equation
     DiffRadTilt = DiffRadTiltHZ + DiffRadTiltDOM + DiffRadTiltCS
     "total diffuse irradiation on a tilted Surface";
 
-    OutTotalRadTilted.I = max(0, BeamRadTilt + DiffRadTilt + RadGroundRefl)
+  OutTotalRadTilted.H   = max(0, BeamRadTilt + DiffRadTilt + RadGroundRefl)
     "output connector for the total Irradiation on a tilted Surface";
 
   // calculation of direct. diffuse and ground reflection radiation on tilted surface
-  OutTotalRadTilted.I_dir = BeamRadTilt;
-  OutTotalRadTilted.I_diff = DiffRadTilt;
-  OutTotalRadTilted.I_gr = RadGroundRefl;
-  OutTotalRadTilted.AOI = Modelica.Math.acos(cos_theta); // in rad
+  OutTotalRadTilted.HDir = BeamRadTilt;
+  OutTotalRadTilted.HDif = DiffRadTilt;
+  OutTotalRadTilted.HGrd = RadGroundRefl;
+  OutTotalRadTilted.incAng = Modelica.Math.acos(cos_theta);
+                                                         // in rad
 
 //Output
   BeamRadTilt=BeamRadTiltOut;

--- a/AixLib/Obsolete/Year2020/ThermalZones/HighOrder/Components/Walls/Wall_ASHRAE140.mo
+++ b/AixLib/Obsolete/Year2020/ThermalZones/HighOrder/Components/Walls/Wall_ASHRAE140.mo
@@ -143,7 +143,7 @@ public
   AixLib.ThermalZones.HighOrder.Components.Sunblinds.Sunblind Sunblind(
     final n=1,
     final gsunblind={Blinding},
-    final Imax=LimitSolIrr,
+    final H_max=LimitSolIrr,
     final TOutAirLimit=TOutAirLimit) if outside and withWindow and withSunblind
     annotation (Placement(transformation(extent={{-44,-22},{-21,4}})));
 
@@ -299,7 +299,8 @@ end if;
 
   connect(port_outside, tempOutAirSensor.port) annotation (Line(points={{-98,4},
           {-70,4},{-70,-14},{-66,-14}}, color={191,0,0}));
-  connect(tempOutAirSensor.T, Sunblind.TOutAir) annotation (Line(points={{-58,-14},{-54,-14},{-54,-13.875},{-45.4375,-13.875}},
+  connect(tempOutAirSensor.T, Sunblind.TOutAir) annotation (Line(points={{-57.6,
+          -14},{-54,-14},{-54,-13.875},{-45.4375,-13.875}},
                                                       color={0,0,127}));
   connect(absSolarRadWin.port, Wall.port_b1) annotation (Line(points={{29,80},{7,
           80},{7,57},{-9.22,57},{-9.22,33.8}}, color={191,0,0}));

--- a/AixLib/Obsolete/Year2020/ThermalZones/HighOrder/Components/Walls/Wall_ASHRAE140.mo
+++ b/AixLib/Obsolete/Year2020/ThermalZones/HighOrder/Components/Walls/Wall_ASHRAE140.mo
@@ -195,7 +195,7 @@ public
         transformation(
         extent={{-10,-10},{10,10}},
         origin={-20,88})));
-  Modelica.Blocks.Sources.RealExpression SolarRadTotal(y=SolarRadiationPort.I) if outside
+  Modelica.Blocks.Sources.RealExpression SolarRadTotal(y=SolarRadiationPort.H) if outside
     annotation (Placement(transformation(extent={{-80,86},{-60,106}})));
   Modelica.Thermal.HeatTransfer.Sensors.TemperatureSensor tempOutAirSensor
     "Outdoor air (dry bulb) temperature sensor"

--- a/AixLib/Obsolete/Year2021/Electrical/PVSystem.mo
+++ b/AixLib/Obsolete/Year2021/Electrical/PVSystem.mo
@@ -1,4 +1,4 @@
-within AixLib.Obsolete.Year2021.Electrical;
+﻿within AixLib.Obsolete.Year2021.Electrical;
 package PVSystem
 
   model PVSystem "PVSystem"
@@ -15,7 +15,7 @@ package PVSystem
       annotation (Placement(transformation(extent={{-124,-12},{-100,14}}),
           iconTransformation(extent={{-136,-24},{-100,14}})));
 
-    Modelica.Blocks.Sources.RealExpression realExpression(y=IcTotalRad.I)
+    Modelica.Blocks.Sources.RealExpression realExpression(y=IcTotalRad.H)
       annotation (Placement(transformation(extent={{-96,-10},{-76,10}})));
   equation
 

--- a/AixLib/Resources/Scripts/ConvertAixLib_from_2.1.1_to_2.1.2.mos
+++ b/AixLib/Resources/Scripts/ConvertAixLib_from_2.1.1_to_2.1.2.mos
@@ -18,3 +18,4 @@ convertElement("AixLib.Utilities.Sources.PrescribedSolarRad", "I_dir[n]", "HDir[
 convertElement("AixLib.Utilities.Sources.PrescribedSolarRad", "I_diff[n]", "HDif[n]");
 convertElement("AixLib.Utilities.Sources.PrescribedSolarRad", "I_gr[n]", "HGrd[n]");
 convertElement("AixLib.Utilities.Sources.PrescribedSolarRad", "AOI[n]", "incAng[n]");
+convertElement("AixLib.ThermalZones.HighOrder.Components.Sunblinds.BaseClasses.PartialSunblind", "Imax", "H_max");

--- a/AixLib/Resources/Scripts/ConvertAixLib_from_2.1.1_to_2.1.2.mos
+++ b/AixLib/Resources/Scripts/ConvertAixLib_from_2.1.1_to_2.1.2.mos
@@ -1,0 +1,20 @@
+clear
+
+convertClear();
+
+convertElement("AixLib.Utilities.Interfaces.SolarRad_in", "I", "H");
+convertElement("AixLib.Utilities.Interfaces.SolarRad_in", "I_dir", "HDir");
+convertElement("AixLib.Utilities.Interfaces.SolarRad_in", "I_diff", "HDif");
+convertElement("AixLib.Utilities.Interfaces.SolarRad_in", "I_gr", "HGrd");
+convertElement("AixLib.Utilities.Interfaces.SolarRad_in", "AOI", "incAng");
+convertElement("AixLib.Utilities.Interfaces.SolarRad_out", "I", "H");
+convertElement("AixLib.Utilities.Interfaces.SolarRad_out", "I_dir", "HDir");
+convertElement("AixLib.Utilities.Interfaces.SolarRad_out", "I_diff", "HDif");
+convertElement("AixLib.Utilities.Interfaces.SolarRad_out", "I_gr", "HGrd");
+convertElement("AixLib.Utilities.Interfaces.SolarRad_out", "AOI", "incAng");
+convertElement("AixLib.Utilities.Sources.PrescribedSolarRad", "solarRad_out[n]", "solRadOut[n]");
+convertElement("AixLib.Utilities.Sources.PrescribedSolarRad", "I[n]", "H[n]");
+convertElement("AixLib.Utilities.Sources.PrescribedSolarRad", "I_dir[n]", "HDir[n]");
+convertElement("AixLib.Utilities.Sources.PrescribedSolarRad", "I_diff[n]", "HDif[n]");
+convertElement("AixLib.Utilities.Sources.PrescribedSolarRad", "I_gr[n]", "HGrd[n]");
+convertElement("AixLib.Utilities.Sources.PrescribedSolarRad", "AOI[n]", "incAng[n]");

--- a/AixLib/ThermalZones/HighOrder/Components/Examples/Walls/OutsideWall.mo
+++ b/AixLib/ThermalZones/HighOrder/Components/Examples/Walls/OutsideWall.mo
@@ -42,12 +42,18 @@ equation
   connect(heatStarToComb.portConvRadComb, outerWall.thermStarComb_inside) annotation (Line(points={{-48,26},{-42,26},{-42,25},{-30,25}}, color={191,0,0}));
   connect(Toutside.port, outerWall.port_outside) annotation (Line(points={{20,22},{2,22},{2,25},{-17.7,25}}, color={191,0,0}));
   connect(WindSpeed.y, outerWall.WindSpeedPort) annotation (Line(points={{11.1,56},{-4,56},{-4,66.8},{-17.7,66.8}}, color={0,0,127}));
-  connect(varRad.solarRad_out[1], outerWall.SolarRadiationPort) annotation (Line(points={{41,80},{12,80},{12,77.25},{-16.2,77.25}}, color={255,128,0}));
-  connect(Solarradiation.y, varRad.AOI[1]) annotation (Line(points={{77.1,79},{68.55,79},{68.55,87},{59,87}}, color={0,0,127}));
-  connect(Solarradiation.y, varRad.I_gr[1]) annotation (Line(points={{77.1,79},{67.55,79},{67.55,83.1},{58.9,83.1}}, color={0,0,127}));
-  connect(Solarradiation.y, varRad.I_diff[1]) annotation (Line(points={{77.1,79},{68.55,79},{68.55,79},{59,79}}, color={0,0,127}));
-  connect(Solarradiation.y, varRad.I_dir[1]) annotation (Line(points={{77.1,79},{67.55,79},{67.55,75},{59,75}}, color={0,0,127}));
-  connect(Solarradiation.y, varRad.I[1]) annotation (Line(points={{77.1,79},{68.55,79},{68.55,71.1},{58.9,71.1}}, color={0,0,127}));
+  connect(varRad.solRadOut[1], outerWall.SolarRadiationPort) annotation (Line(
+        points={{41,80},{12,80},{12,77.25},{-16.2,77.25}}, color={255,128,0}));
+  connect(Solarradiation.y, varRad.incAng[1]) annotation (Line(points={{77.1,79},
+          {68.55,79},{68.55,87},{59,87}}, color={0,0,127}));
+  connect(Solarradiation.y, varRad.HGrd[1]) annotation (Line(points={{77.1,79},
+          {67.55,79},{67.55,83.1},{58.9,83.1}}, color={0,0,127}));
+  connect(Solarradiation.y, varRad.HDif[1]) annotation (Line(points={{77.1,79},
+          {68.55,79},{68.55,79},{59,79}}, color={0,0,127}));
+  connect(Solarradiation.y, varRad.HDir[1]) annotation (Line(points={{77.1,79},
+          {67.55,79},{67.55,75},{59,75}}, color={0,0,127}));
+  connect(Solarradiation.y, varRad.H[1]) annotation (Line(points={{77.1,79},{
+          68.55,79},{68.55,71.1},{58.9,71.1}}, color={0,0,127}));
   annotation (experiment(StopTime = 36000, Interval = 60, Algorithm = "Lsodar"),Documentation(info = "<html><h4>
   <span style=\"color:#008000\">Overview</span>
 </h4>

--- a/AixLib/ThermalZones/HighOrder/Components/Examples/WindowsDoors/WindowSimple.mo
+++ b/AixLib/ThermalZones/HighOrder/Components/Examples/WindowsDoors/WindowSimple.mo
@@ -17,22 +17,18 @@ model WindowSimple
 equation
   connect(Toutside.port, windowSimple.port_outside) annotation(Line(points = {{-42, 10}, {-34, 10}, {-34, 10.4}, {-22.2, 10.4}}, color = {191, 0, 0}));
   connect(windowSimple.port_inside, Tinside.port) annotation(Line(points = {{10.2, 10.4}, {24, 10.4}, {24, 10}, {38, 10}}, color = {191, 0, 0}));
-  connect(varRad.solarRad_out[1], windowSimple.solarRad_in) annotation(Line(points = {{-47, 50}, {-32, 50}, {-32, 21.6}, {-22.2, 21.6}}, color = {255, 128, 0}));
-  connect(SolarRadiation.y, varRad.I[1]) annotation (Line(
-      points={{-79,50},{-74,50},{-74,58.9},{-64.9,58.9}},
-      color={0,0,127}));
-  connect(SolarRadiation.y, varRad.I_dir[1]) annotation (Line(
-      points={{-79,50},{-74,50},{-74,55},{-65,55}},
-      color={0,0,127}));
-  connect(SolarRadiation.y, varRad.I_diff[1]) annotation (Line(
-      points={{-79,50},{-76,50},{-76,48},{-74,48},{-74,51},{-65,51}},
-      color={0,0,127}));
-  connect(SolarRadiation.y, varRad.I_gr[1]) annotation (Line(
-      points={{-79,50},{-74,50},{-74,46.9},{-64.9,46.9}},
-      color={0,0,127}));
-  connect(SolarRadiation.y, varRad.AOI[1]) annotation (Line(
-      points={{-79,50},{-74,50},{-74,43},{-65,43}},
-      color={0,0,127}));
+  connect(varRad.solRadOut[1], windowSimple.solarRad_in) annotation (Line(
+        points={{-47,50},{-32,50},{-32,21.6},{-22.2,21.6}}, color={255,128,0}));
+  connect(SolarRadiation.y, varRad.H[1]) annotation (Line(points={{-79,50},{-74,
+          50},{-74,58.9},{-64.9,58.9}}, color={0,0,127}));
+  connect(SolarRadiation.y, varRad.HDir[1]) annotation (Line(points={{-79,50},{
+          -74,50},{-74,55},{-65,55}}, color={0,0,127}));
+  connect(SolarRadiation.y, varRad.HDif[1]) annotation (Line(points={{-79,50},{
+          -76,50},{-76,48},{-74,48},{-74,51},{-65,51}}, color={0,0,127}));
+  connect(SolarRadiation.y, varRad.HGrd[1]) annotation (Line(points={{-79,50},{
+          -74,50},{-74,46.9},{-64.9,46.9}}, color={0,0,127}));
+  connect(SolarRadiation.y, varRad.incAng[1]) annotation (Line(points={{-79,50},
+          {-74,50},{-74,43},{-65,43}}, color={0,0,127}));
   connect(Tinside1.port, windowSimple.radPort) annotation (Line(points={{38,42},{26,42},{26,21.6},{10.2,21.6}}, color={191,0,0}));
   annotation (experiment(StopTime = 3600, Interval = 60, Algorithm = "Lsodar"),Documentation(info = "<html><h4>
   <span style=\"color:#008000\">Overview</span>

--- a/AixLib/ThermalZones/HighOrder/Components/Shadow/RadiationTransfer.mo
+++ b/AixLib/ThermalZones/HighOrder/Components/Shadow/RadiationTransfer.mo
@@ -43,17 +43,17 @@ equation
           {-2,56}}, color={0,0,127}));
   connect(hDifTil.H, add.u2) annotation (Line(points={{-39,30},{-8,30},{-8,44},{
           -2,44}}, color={0,0,127}));
-  connect(add.y, preSolRad.I[1]) annotation (Line(points={{21,50},{30,50},{30,17.8},
-          {42.2,17.8}}, color={0,0,127}));
-  connect(hDirTil.H, preSolRad.I_dir[1]) annotation (Line(points={{-39,70},{-12,
+  connect(add.y, preSolRad.H[1]) annotation (Line(points={{21,50},{30,50},{30,
+          17.8},{42.2,17.8}}, color={0,0,127}));
+  connect(hDirTil.H, preSolRad.HDir[1]) annotation (Line(points={{-39,70},{-12,
           70},{-12,10},{42,10}}, color={0,0,127}));
-  connect(hDifTil.H, preSolRad.I_diff[1]) annotation (Line(points={{-39,30},{-20,
+  connect(hDifTil.H, preSolRad.HDif[1]) annotation (Line(points={{-39,30},{-20,
           30},{-20,2},{42,2}}, color={0,0,127}));
-  connect(const.y, preSolRad.I_gr[1]) annotation (Line(points={{-39,-10},{-30,-10},
+  connect(const.y, preSolRad.HGrd[1]) annotation (Line(points={{-39,-10},{-30,-10},
           {-30,-6.2},{42.2,-6.2}}, color={0,0,127}));
-  connect(hDirTil.inc, preSolRad.AOI[1]) annotation (Line(points={{-39,66},{-26,
-          66},{-26,-14},{42,-14}}, color={0,0,127}));
-  connect(preSolRad.solarRad_out[1], solRadOut)
+  connect(hDirTil.inc, preSolRad.incAng[1]) annotation (Line(points={{-39,66},{
+          -26,66},{-26,-14},{42,-14}}, color={0,0,127}));
+  connect(preSolRad.solRadOut[1], solRadOut)
     annotation (Line(points={{78,0},{110,0}}, color={255,128,0}));
   annotation (Icon(coordinateSystem(preserveAspectRatio=false), graphics={
         Text(

--- a/AixLib/ThermalZones/HighOrder/Components/Shadow/ShadowEffect.mo
+++ b/AixLib/ThermalZones/HighOrder/Components/Shadow/ShadowEffect.mo
@@ -51,21 +51,21 @@ equation
   else
     gShaDir = 0;
   end if;
-  solRadOut.I = solRadOut.I_dir + solRadOut.I_diff;
-  solRadOut.I_dir = solRadIn.I_dir*gShaDir;
+  solRadOut.H =solRadOut.HDir + solRadOut.HDif;
+  solRadOut.HDir = solRadIn.HDir*gShaDir;
   // Calculate the shadow factor for diffuse radiation
   if calMod == AixLib.ThermalZones.HighOrder.Components.Shadow.Types.selectorShadowEffectMode.constRedDiffAllDir then
     gShaDif = gShaDif_mean;
-    solRadOut.I_diff = solRadIn.I_diff*gShaDif*redFacDifRad;
+    solRadOut.HDif = solRadIn.HDif*gShaDif*redFacDifRad;
   elseif calMod == AixLib.ThermalZones.HighOrder.Components.Shadow.Types.selectorShadowEffectMode.constRedDiffPerpDir then
     gShaDif = atan((heiWinMax+heiWinMin)/2 / lenShie)/(Modelica.Constants.pi/2);
-    solRadOut.I_diff = solRadIn.I_diff*gShaDif*redFacDifRad;
+    solRadOut.HDif = solRadIn.HDif*gShaDif*redFacDifRad;
   else
     gShaDif = 99;  //Not used in the following equation, to avoid sigular structure
-    solRadOut.I_diff = solRadIn.I_diff*gShaDir*redFacDifRad;
+    solRadOut.HDif = solRadIn.HDif*gShaDir*redFacDifRad;
   end if;
-  solRadOut.I_gr = solRadIn.I_gr;
-  solRadOut.AOI = solRadIn.AOI;
+  solRadOut.HGrd =solRadIn.HGrd;
+  solRadOut.incAng = solRadIn.incAng;
 
   connect(shaLen.weaBus, weaBus) annotation (Line(
       points={{-40,0},{-74,0},{-74,80},{-100,80}},

--- a/AixLib/ThermalZones/HighOrder/Components/Sunblinds/BaseClasses/PartialSunblind.mo
+++ b/AixLib/ThermalZones/HighOrder/Components/Sunblinds/BaseClasses/PartialSunblind.mo
@@ -7,11 +7,10 @@ partial model PartialSunblind "A Base Class for Sunblindes"
     each min=0.0,
     each max=1.0) = {1,1,1,1}
     "Total energy transmittances if sunblind is closed";
-  parameter Modelica.Units.SI.RadiantEnergyFluenceRate Imax
+  parameter Modelica.Units.SI.RadiantEnergyFluenceRate H_max
     "Intensity at which the sunblind closes (see also TOutAirLimit)";
 
-  Utilities.Interfaces.SolarRad_in
-                                 Rad_In[n]
+  AixLib.Utilities.Interfaces.SolarRad_in Rad_In[n]
     annotation (Placement(transformation(extent={{-100,0},{-80,20}})));
   Modelica.Blocks.Interfaces.RealOutput sunblindonoff[n] annotation (Placement(
         transformation(
@@ -21,12 +20,10 @@ partial model PartialSunblind "A Base Class for Sunblindes"
         extent={{-10,-10},{10,10}},
         rotation=-90,
         origin={0,-90})));
-  Utilities.Interfaces.SolarRad_out
-                                  Rad_Out[n]
+  AixLib.Utilities.Interfaces.SolarRad_out Rad_Out[n]
     annotation (Placement(transformation(extent={{80,0},{100,20}})));
 
 initial equation
   assert(n==size(gsunblind,1),"gsunblind has to have n elements");
-
   annotation (Diagram(coordinateSystem(extent={{-80,-80},{80,80}})), Icon(coordinateSystem(extent={{-80,-80},{80,80}})));
 end PartialSunblind;

--- a/AixLib/ThermalZones/HighOrder/Components/Sunblinds/Sunblind.mo
+++ b/AixLib/ThermalZones/HighOrder/Components/Sunblinds/Sunblind.mo
@@ -191,6 +191,10 @@ equation
 </html>",
         revisions="<html><ul>
   <li>
+    May 12, 2025, by Jun Jiang:<br/>
+    Change variable names (see <a href=\"https://github.com/RWTH-EBC/AixLib/issues/1525\">issue 1525</a>)
+  </li>
+  <li>
     <i>January 16, 2015&#160;</i> by Ana Constantin:<br/>
     Implemented as extending from PartialSunblind and using the new
     solar radiation connectors

--- a/AixLib/ThermalZones/HighOrder/Components/Sunblinds/Sunblind.mo
+++ b/AixLib/ThermalZones/HighOrder/Components/Sunblinds/Sunblind.mo
@@ -10,19 +10,19 @@ model Sunblind "Reduces beam at Imax and TOutAirLimit"
     annotation (Placement(transformation(extent={{-112,-56},{-80,-24}}), iconTransformation(extent={{-100,-40},{-80,-20}})));
 equation
    for i in 1:n loop
-     if (Rad_In[i].I>Imax and TOutAir > TOutAirLimit) then
-       Rad_Out[i].I=Rad_In[i].I*gsunblind[i];
-       Rad_Out[i].I_dir=Rad_In[i].I_dir*gsunblind[i];
-       Rad_Out[i].I_diff=Rad_In[i].I_diff*gsunblind[i];
-       Rad_Out[i].I_gr=Rad_In[i].I_gr*gsunblind[i];
-       Rad_Out[i].AOI=Rad_In[i].AOI;
+     if (Rad_In[i].H>Imax and TOutAir > TOutAirLimit) then
+      Rad_Out[i].H =Rad_In[i].H*gsunblind[i];
+      Rad_Out[i].HDir = Rad_In[i].HDir*gsunblind[i];
+      Rad_Out[i].HDif = Rad_In[i].HDif*gsunblind[i];
+      Rad_Out[i].HGrd =Rad_In[i].HGrd*gsunblind[i];
+      Rad_Out[i].incAng = Rad_In[i].incAng;
        sunblindonoff[i]=1-gsunblind[i];
      else // quantity of solar radiation remains unchanged
-       Rad_Out[i].I=Rad_In[i].I;
-       Rad_Out[i].I_dir=Rad_In[i].I_dir;
-       Rad_Out[i].I_diff=Rad_In[i].I_diff;
-       Rad_Out[i].I_gr=Rad_In[i].I_gr;
-       Rad_Out[i].AOI=Rad_In[i].AOI;
+      Rad_Out[i].H =Rad_In[i].H;
+      Rad_Out[i].HDir = Rad_In[i].HDir;
+      Rad_Out[i].HDif = Rad_In[i].HDif;
+      Rad_Out[i].HGrd =Rad_In[i].HGrd;
+      Rad_Out[i].incAng = Rad_In[i].incAng;
        sunblindonoff[i]=0;
      end if;
      end for;

--- a/AixLib/ThermalZones/HighOrder/Components/Sunblinds/Sunblind.mo
+++ b/AixLib/ThermalZones/HighOrder/Components/Sunblinds/Sunblind.mo
@@ -9,23 +9,23 @@ model Sunblind "Reduces beam at Imax and TOutAirLimit"
     "Outdoor air (dry bulb) temperature"
     annotation (Placement(transformation(extent={{-112,-56},{-80,-24}}), iconTransformation(extent={{-100,-40},{-80,-20}})));
 equation
-   for i in 1:n loop
-     if (Rad_In[i].H>Imax and TOutAir > TOutAirLimit) then
-      Rad_Out[i].H =Rad_In[i].H*gsunblind[i];
+  for i in 1:n loop
+    if (Rad_In[i].H > H_max and TOutAir > TOutAirLimit) then
+      Rad_Out[i].H = Rad_In[i].H*gsunblind[i];
       Rad_Out[i].HDir = Rad_In[i].HDir*gsunblind[i];
       Rad_Out[i].HDif = Rad_In[i].HDif*gsunblind[i];
-      Rad_Out[i].HGrd =Rad_In[i].HGrd*gsunblind[i];
+      Rad_Out[i].HGrd = Rad_In[i].HGrd*gsunblind[i];
       Rad_Out[i].incAng = Rad_In[i].incAng;
-       sunblindonoff[i]=1-gsunblind[i];
-     else // quantity of solar radiation remains unchanged
-      Rad_Out[i].H =Rad_In[i].H;
+      sunblindonoff[i] = 1 - gsunblind[i];
+    else // quantity of solar radiation remains unchanged
+      Rad_Out[i].H = Rad_In[i].H;
       Rad_Out[i].HDir = Rad_In[i].HDir;
       Rad_Out[i].HDif = Rad_In[i].HDif;
-      Rad_Out[i].HGrd =Rad_In[i].HGrd;
+      Rad_Out[i].HGrd = Rad_In[i].HGrd;
       Rad_Out[i].incAng = Rad_In[i].incAng;
-       sunblindonoff[i]=0;
-     end if;
-     end for;
+      sunblindonoff[i]=0;
+    end if;
+  end for;
             annotation ( Icon(coordinateSystem(
           preserveAspectRatio=false, extent={{-80,-80},{80,80}}),
                                                 graphics={

--- a/AixLib/ThermalZones/HighOrder/Components/Sunblinds/SunblindTimeVariable.mo
+++ b/AixLib/ThermalZones/HighOrder/Components/Sunblinds/SunblindTimeVariable.mo
@@ -1007,6 +1007,10 @@ equation
 </html>",
         revisions="<html><ul>
   <li>
+    May 12, 2025, by Jun Jiang:<br/>
+    Change variable names (see <a href=\"https://github.com/RWTH-EBC/AixLib/issues/1525\">issue 1525</a>)
+  </li>
+  <li>
     <i>January 16, 2015&#160;</i> by Ana Constantin:<br/>
     Implemented as extending from PartialSunblind and using the new
     solar radiation connectors

--- a/AixLib/ThermalZones/HighOrder/Components/Sunblinds/SunblindTimeVariable.mo
+++ b/AixLib/ThermalZones/HighOrder/Components/Sunblinds/SunblindTimeVariable.mo
@@ -1,7 +1,8 @@
 within AixLib.ThermalZones.HighOrder.Components.Sunblinds;
 model SunblindTimeVariable
-  extends AixLib.ThermalZones.HighOrder.Components.Sunblinds.BaseClasses.PartialSunblind(Imax=0);
-
+  extends
+    AixLib.ThermalZones.HighOrder.Components.Sunblinds.BaseClasses.PartialSunblind(
+     H_max=0);
 
   Modelica.Blocks.Sources.CombiTimeTable combiTimeTable(table=[0,0; 600,0; 1200,
         0; 1800,0; 2400,0; 3000,0; 3600,0; 4200,0; 4800,0; 5400,0; 6000,0; 6600,
@@ -832,14 +833,14 @@ model SunblindTimeVariable
         1; 3540000,1; 3540600,1; 3541200,1; 3541800,1; 3542400,1])
     annotation (Placement(transformation(extent={{-22,36},{-2,56}})));
 equation
-   for i in 1:n loop
-    Rad_Out[i].H   =Rad_In[i].H*gsunblind[i]*combiTimeTable.y[1];
+  for i in 1:n loop
+    Rad_Out[i].H = Rad_In[i].H*gsunblind[i]*combiTimeTable.y[1];
     Rad_Out[i].HDir = Rad_In[i].HDir*gsunblind[i]*combiTimeTable.y[1];
     Rad_Out[i].HDif = Rad_In[i].HDif*gsunblind[i]*combiTimeTable.y[1];
-    Rad_Out[i].HGrd   =Rad_In[i].HGrd*gsunblind[i]*combiTimeTable.y[1];
+    Rad_Out[i].HGrd = Rad_In[i].HGrd*gsunblind[i]*combiTimeTable.y[1];
     Rad_Out[i].incAng = Rad_In[i].incAng;
-       sunblindonoff[i]=1-gsunblind[i]*combiTimeTable.y[1];
-     end for;
+    sunblindonoff[i] = 1 - gsunblind[i]*combiTimeTable.y[1];
+  end for;
     annotation (Placement(transformation(extent={{-112,-56},{-80,-24}}), iconTransformation(extent={{-100,-40},{-80,-20}})),
                          Icon(coordinateSystem(
           preserveAspectRatio=false, extent={{-80,-80},{80,80}}),

--- a/AixLib/ThermalZones/HighOrder/Components/Sunblinds/SunblindTimeVariable.mo
+++ b/AixLib/ThermalZones/HighOrder/Components/Sunblinds/SunblindTimeVariable.mo
@@ -839,7 +839,7 @@ equation
     Rad_Out[i].HDif = Rad_In[i].HDif*gsunblind[i]*combiTimeTable.y[1];
     Rad_Out[i].HGrd = Rad_In[i].HGrd*gsunblind[i]*combiTimeTable.y[1];
     Rad_Out[i].incAng = Rad_In[i].incAng;
-    sunblindonoff[i] = 1 - gsunblind[i]*combiTimeTable.y[1];
+    sunblindonoff[i] = 1 - gsunblind[i] * combiTimeTable.y[1];
   end for;
     annotation (Placement(transformation(extent={{-112,-56},{-80,-24}}), iconTransformation(extent={{-100,-40},{-80,-20}})),
                          Icon(coordinateSystem(

--- a/AixLib/ThermalZones/HighOrder/Components/Sunblinds/SunblindTimeVariable.mo
+++ b/AixLib/ThermalZones/HighOrder/Components/Sunblinds/SunblindTimeVariable.mo
@@ -833,11 +833,11 @@ model SunblindTimeVariable
     annotation (Placement(transformation(extent={{-22,36},{-2,56}})));
 equation
    for i in 1:n loop
-       Rad_Out[i].I=Rad_In[i].I*gsunblind[i]*combiTimeTable.y[1];
-       Rad_Out[i].I_dir=Rad_In[i].I_dir*gsunblind[i]*combiTimeTable.y[1];
-       Rad_Out[i].I_diff=Rad_In[i].I_diff*gsunblind[i]*combiTimeTable.y[1];
-       Rad_Out[i].I_gr=Rad_In[i].I_gr*gsunblind[i]*combiTimeTable.y[1];
-       Rad_Out[i].AOI=Rad_In[i].AOI;
+    Rad_Out[i].H   =Rad_In[i].H*gsunblind[i]*combiTimeTable.y[1];
+    Rad_Out[i].HDir = Rad_In[i].HDir*gsunblind[i]*combiTimeTable.y[1];
+    Rad_Out[i].HDif = Rad_In[i].HDif*gsunblind[i]*combiTimeTable.y[1];
+    Rad_Out[i].HGrd   =Rad_In[i].HGrd*gsunblind[i]*combiTimeTable.y[1];
+    Rad_Out[i].incAng = Rad_In[i].incAng;
        sunblindonoff[i]=1-gsunblind[i]*combiTimeTable.y[1];
      end for;
     annotation (Placement(transformation(extent={{-112,-56},{-80,-24}}), iconTransformation(extent={{-100,-40},{-80,-20}})),

--- a/AixLib/ThermalZones/HighOrder/Components/Sunblinds/Sunblind_Task44.mo
+++ b/AixLib/ThermalZones/HighOrder/Components/Sunblinds/Sunblind_Task44.mo
@@ -1007,6 +1007,10 @@ equation
 </html>",
         revisions="<html><ul>
   <li>
+    May 12, 2025, by Jun Jiang:<br/>
+    Change variable names (see <a href=\"https://github.com/RWTH-EBC/AixLib/issues/1525\">issue 1525</a>)
+  </li>
+  <li>
     <i>January 16, 2015&#160;</i> by Ana Constantin:<br/>
     Implemented as extending from PartialSunblind and using the new
     solar radiation connectors

--- a/AixLib/ThermalZones/HighOrder/Components/Sunblinds/Sunblind_Task44.mo
+++ b/AixLib/ThermalZones/HighOrder/Components/Sunblinds/Sunblind_Task44.mo
@@ -1,7 +1,8 @@
 ﻿within AixLib.ThermalZones.HighOrder.Components.Sunblinds;
 model Sunblind_Task44 "sunblinds modell after suggestions by IEA Task 44"
-extends AixLib.ThermalZones.HighOrder.Components.Sunblinds.BaseClasses.PartialSunblind(Imax=0);
-
+  extends
+    AixLib.ThermalZones.HighOrder.Components.Sunblinds.BaseClasses.PartialSunblind(
+     H_max=0);
 
   Modelica.Blocks.Sources.CombiTimeTable combiTimeTable(table=[0,0; 600,0; 1200,
         0; 1800,0; 2400,0; 3000,0; 3600,0; 4200,0; 4800,0; 5400,0; 6000,0; 6600,
@@ -832,14 +833,14 @@ extends AixLib.ThermalZones.HighOrder.Components.Sunblinds.BaseClasses.PartialSu
         1; 3540000,1; 3540600,1; 3541200,1; 3541800,1; 3542400,1])
     annotation (Placement(transformation(extent={{-22,36},{-2,56}})));
 equation
-   for i in 1:n loop
-    Rad_Out[i].H   =Rad_In[i].H*gsunblind[i]*combiTimeTable.y[1];
+  for i in 1:n loop
+    Rad_Out[i].H = Rad_In[i].H*gsunblind[i]*combiTimeTable.y[1];
     Rad_Out[i].HDir = Rad_In[i].HDir*gsunblind[i]*combiTimeTable.y[1];
     Rad_Out[i].HDif = Rad_In[i].HDif*gsunblind[i]*combiTimeTable.y[1];
-    Rad_Out[i].HGrd   =Rad_In[i].HGrd*gsunblind[i]*combiTimeTable.y[1];
+    Rad_Out[i].HGrd = Rad_In[i].HGrd*gsunblind[i]*combiTimeTable.y[1];
     Rad_Out[i].incAng = Rad_In[i].incAng;
-       sunblindonoff[i]=1-gsunblind[i]*combiTimeTable.y[1];
-     end for;
+    sunblindonoff[i] = 1 - gsunblind[i]*combiTimeTable.y[1];
+  end for;
     annotation (Placement(transformation(extent={{-112,-56},{-80,-24}}), iconTransformation(extent={{-100,-40},{-80,-20}})),
                          Icon(coordinateSystem(
           preserveAspectRatio=false, extent={{-80,-80},{80,80}}),

--- a/AixLib/ThermalZones/HighOrder/Components/Sunblinds/Sunblind_Task44.mo
+++ b/AixLib/ThermalZones/HighOrder/Components/Sunblinds/Sunblind_Task44.mo
@@ -833,11 +833,11 @@ extends AixLib.ThermalZones.HighOrder.Components.Sunblinds.BaseClasses.PartialSu
     annotation (Placement(transformation(extent={{-22,36},{-2,56}})));
 equation
    for i in 1:n loop
-       Rad_Out[i].I=Rad_In[i].I*gsunblind[i]*combiTimeTable.y[1];
-       Rad_Out[i].I_dir=Rad_In[i].I_dir*gsunblind[i]*combiTimeTable.y[1];
-       Rad_Out[i].I_diff=Rad_In[i].I_diff*gsunblind[i]*combiTimeTable.y[1];
-       Rad_Out[i].I_gr=Rad_In[i].I_gr*gsunblind[i]*combiTimeTable.y[1];
-       Rad_Out[i].AOI=Rad_In[i].AOI;
+    Rad_Out[i].H   =Rad_In[i].H*gsunblind[i]*combiTimeTable.y[1];
+    Rad_Out[i].HDir = Rad_In[i].HDir*gsunblind[i]*combiTimeTable.y[1];
+    Rad_Out[i].HDif = Rad_In[i].HDif*gsunblind[i]*combiTimeTable.y[1];
+    Rad_Out[i].HGrd   =Rad_In[i].HGrd*gsunblind[i]*combiTimeTable.y[1];
+    Rad_Out[i].incAng = Rad_In[i].incAng;
        sunblindonoff[i]=1-gsunblind[i]*combiTimeTable.y[1];
      end for;
     annotation (Placement(transformation(extent={{-112,-56},{-80,-24}}), iconTransformation(extent={{-100,-40},{-80,-20}})),

--- a/AixLib/ThermalZones/HighOrder/Components/Walls/Wall.mo
+++ b/AixLib/ThermalZones/HighOrder/Components/Walls/Wall.mo
@@ -157,7 +157,7 @@ parameter DataBase.Surfaces.RoughnessForHT.PolynomialCoefficients_ASHRAEHandbook
   Sunblinds.Sunblind Sunblind(
     final n=1,
     final gsunblind={Blinding},
-    final Imax=LimitSolIrr,
+    final H_max=LimitSolIrr,
     final TOutAirLimit=TOutAirLimit)
                       if outside and withWindow and withSunblind
     annotation (Placement(transformation(extent={{-52,-44},{-36,-28}})));

--- a/AixLib/ThermalZones/HighOrder/Components/WindowsDoors/BaseClasses/CorrectionSolarGain/CorGSimple.mo
+++ b/AixLib/ThermalZones/HighOrder/Components/WindowsDoors/BaseClasses/CorrectionSolarGain/CorGSimple.mo
@@ -4,7 +4,7 @@ model CorGSimple "Simple correction with factor g for shortwave solar transmitta
 
 equation
     for i in 1:n loop
-      solarRadWinTrans[i] = SR_input[i].I*g;
+      solarRadWinTrans[i] =SR_input[i].H *g;
     end for;
 
   annotation (Documentation(info="<html><h4>

--- a/AixLib/ThermalZones/HighOrder/Components/WindowsDoors/BaseClasses/CorrectionSolarGain/CorG_ASHRAE140.mo
+++ b/AixLib/ThermalZones/HighOrder/Components/WindowsDoors/BaseClasses/CorrectionSolarGain/CorG_ASHRAE140.mo
@@ -45,8 +45,10 @@ model CorG_ASHRAE140
 equation
   for i in 1:n loop
     // Snell's Law
-    AOI[i] = SR_input[i].AOI; // in rad
-    AOI_help[i] = to_deg(SR_input[i].AOI); // angle of solar incidence in deg
+    AOI[i] =SR_input[i].incAng;
+                              // in rad
+    AOI_help[i] =to_deg(SR_input[i].incAng);
+                                           // angle of solar incidence in deg
     y=AOI_help[i];
 
     AOR[i] = asin(sin(AOI[i])/INDRG); //  Angle of refraction in deg
@@ -73,7 +75,8 @@ equation
     SHGC[i]= T[i]+S[i];
 
     //Solar radiation transmitted through window
-    solarRadWinTrans[i]= (SR_input[i].I_diff + SR_input[i].I_dir + SR_input[i].I_gr) * SHGC[i];
+    solarRadWinTrans[i]=(SR_input[i].HDif + SR_input[i].HDir + SR_input[i].HGrd)
+      *SHGC[i];
 
   end for;
 

--- a/AixLib/ThermalZones/HighOrder/Components/WindowsDoors/BaseClasses/CorrectionSolarGain/CorG_VDI6007.mo
+++ b/AixLib/ThermalZones/HighOrder/Components/WindowsDoors/BaseClasses/CorrectionSolarGain/CorG_VDI6007.mo
@@ -51,7 +51,7 @@ Real[n] Qsek2_dir;
 Real[n] CorG_dir;  // transmission coefficient correction factor for direct irradiations
 equation
   for i in 1:n loop
-    theta[i] = SR_input[i].AOI;
+    theta[i] =SR_input[i].incAng;
     Ta_dir[i]= (((((A6*to_deg(theta[i])+A5)*to_deg(theta[i])+A4)*to_deg(theta[i])+A3)*to_deg(theta[i])+A2)*to_deg(theta[i])+A1)*to_deg(theta[i])+A0;
     Tai_dir[i]= 0.907^(1/sqrt(1-(sin(theta[i])/1.515)^2));
     Ta1_dir[i]= Ta_dir[i]*Tai_dir[i];
@@ -67,7 +67,8 @@ equation
     CorG_dir[i]= (Ta2_dir[i]+Qsek2_dir[i])/g_dir0;
 
     //calculating the input thermal energy due to solar radiation
-    solarRadWinTrans[i] = ((SR_input[i].I_dir*CorG_dir[i])+(SR_input[i].I_diff*CorG_diff)+(SR_input[i].I_gr*CorG_gr));
+    solarRadWinTrans[i] =((SR_input[i].HDir*CorG_dir[i]) + (SR_input[i].HDif*
+      CorG_diff) + (SR_input[i].HGrd*CorG_gr));
   end for;
 
 annotation (

--- a/AixLib/ThermalZones/HighOrder/Examples/OFDHeatLoad.mo
+++ b/AixLib/ThermalZones/HighOrder/Examples/OFDHeatLoad.mo
@@ -70,23 +70,23 @@ equation
       points={{-49,80},{-46,80},{-46,64},{-41.2,64}},
       color={0,0,127},
       smooth=Smooth.None));
-  connect(constSun.y,varRad. I) annotation (Line(
+  connect(constSun.y,varRad.H)  annotation (Line(
       points={{79,80},{74,80},{74,78.9},{68.9,78.9}},
       color={0,0,127},
       smooth=Smooth.None));
-  connect(constSun.y,varRad. I_dir) annotation (Line(
+  connect(constSun.y, varRad.HDir) annotation (Line(
       points={{79,80},{74,80},{74,75},{69,75}},
       color={0,0,127},
       smooth=Smooth.None));
-  connect(constSun.y,varRad. I_diff) annotation (Line(
+  connect(constSun.y, varRad.HDif) annotation (Line(
       points={{79,80},{74,80},{74,71},{69,71}},
       color={0,0,127},
       smooth=Smooth.None));
-  connect(constSun.y,varRad. I_gr) annotation (Line(
+  connect(constSun.y,varRad.HGrd)  annotation (Line(
       points={{79,80},{74,80},{74,66.9},{68.9,66.9}},
       color={0,0,127},
       smooth=Smooth.None));
-  connect(constSun.y,varRad. AOI) annotation (Line(
+  connect(constSun.y, varRad.incAng) annotation (Line(
       points={{79,80},{74,80},{74,63},{69,63}},
       color={0,0,127},
       smooth=Smooth.None));
@@ -106,25 +106,22 @@ equation
     annotation (Line(points={{-28,64},{-14,64},{-14,45.44}},    color={191,0,0}));
   connect(groundTemp.port, wholeHouseBuildingEnvelope.groundTemp)
     annotation (Line(points={{-42,-90},{14,-90},{14,-10}}, color={191,0,0}));
-  connect(varRad.solarRad_out[1], wholeHouseBuildingEnvelope.North) annotation (
-     Line(points={{51,69.5833},{48,69.5833},{48,28.64},{43.68,28.64}},color={
+  connect(varRad.solRadOut[1], wholeHouseBuildingEnvelope.North) annotation (
+      Line(points={{51,69.5833},{48,69.5833},{48,28.64},{43.68,28.64}}, color={
           255,128,0}));
-  connect(varRad.solarRad_out[2], wholeHouseBuildingEnvelope.East) annotation (
-      Line(points={{51,69.75},{48,69.75},{48,21.36},{43.68,21.36}},
-                                                                 color={255,128,
-          0}));
-  connect(varRad.solarRad_out[3], wholeHouseBuildingEnvelope.South) annotation (
-     Line(points={{51,69.9167},{48,69.9167},{48,14.08},{43.68,14.08}},
-                                                                    color={255,
+  connect(varRad.solRadOut[2], wholeHouseBuildingEnvelope.East) annotation (
+      Line(points={{51,69.75},{48,69.75},{48,21.36},{43.68,21.36}}, color={255,
           128,0}));
-  connect(varRad.solarRad_out[4], wholeHouseBuildingEnvelope.West) annotation (
-      Line(points={{51,70.0833},{48,70.0833},{48,7.36},{43.68,7.36}},color={255,
-          128,0}));
-  connect(varRad.solarRad_out[5], wholeHouseBuildingEnvelope.SolarRadiationPort_RoofN)
-        annotation (Line(points={{51,70.25},{48,70.25},{48,43.2},{43.68,43.2}},
-                                                                         color=
-          {255,128,0}));
-  connect(varRad.solarRad_out[6], wholeHouseBuildingEnvelope.SolarRadiationPort_RoofS)
+  connect(varRad.solRadOut[3], wholeHouseBuildingEnvelope.South) annotation (
+      Line(points={{51,69.9167},{48,69.9167},{48,14.08},{43.68,14.08}}, color={
+          255,128,0}));
+  connect(varRad.solRadOut[4], wholeHouseBuildingEnvelope.West) annotation (
+      Line(points={{51,70.0833},{48,70.0833},{48,7.36},{43.68,7.36}}, color={
+          255,128,0}));
+  connect(varRad.solRadOut[5], wholeHouseBuildingEnvelope.SolarRadiationPort_RoofN)
+    annotation (Line(points={{51,70.25},{48,70.25},{48,43.2},{43.68,43.2}},
+        color={255,128,0}));
+  connect(varRad.solRadOut[6], wholeHouseBuildingEnvelope.SolarRadiationPort_RoofS)
     annotation (Line(points={{51,70.4167},{48,70.4167},{48,35.92},{43.68,35.92}},
         color={255,128,0}));
   connect(heatStarToComb.portConvRadComb, wholeHouseBuildingEnvelope.heatingToRooms) annotation (Line(points={{-28,-20},{-26,-20},{-26,10},{-14,10},{-14,10.16}},        color={191,0,0}));

--- a/AixLib/ThermalZones/HighOrder/Examples/OFD_1Jan.mo
+++ b/AixLib/ThermalZones/HighOrder/Examples/OFD_1Jan.mo
@@ -87,12 +87,12 @@ equation
   TsetValvesSchedule[5] =Modelica.Units.Conversions.to_degC(TSet.y[5]);
   Toutside =Modelica.Units.Conversions.to_degC(Weather.AirTemp);
   //SolarRadiation
-  SolarRadiation[1] = Weather.SolarRadiation_OrientedSurfaces[1].I;
-  SolarRadiation[2] = Weather.SolarRadiation_OrientedSurfaces[2].I;
-  SolarRadiation[3] = Weather.SolarRadiation_OrientedSurfaces[3].I;
-  SolarRadiation[4] = Weather.SolarRadiation_OrientedSurfaces[4].I;
-  SolarRadiation[5] = Weather.SolarRadiation_OrientedSurfaces[5].I;
-  SolarRadiation[6] = Weather.SolarRadiation_OrientedSurfaces[6].I;
+  SolarRadiation[1] =Weather.SolarRadiation_OrientedSurfaces[1].H;
+  SolarRadiation[2] =Weather.SolarRadiation_OrientedSurfaces[2].H;
+  SolarRadiation[3] =Weather.SolarRadiation_OrientedSurfaces[3].H;
+  SolarRadiation[4] =Weather.SolarRadiation_OrientedSurfaces[4].H;
+  SolarRadiation[5] =Weather.SolarRadiation_OrientedSurfaces[5].H;
+  SolarRadiation[6] =Weather.SolarRadiation_OrientedSurfaces[6].H;
   connect(Weather.WindSpeed, OFD.WindSpeedPort) annotation (Line(points={{75.4,80.6},{-48,80.6},{-48,32},{-39.75,32},{-39.75,31.75}},
                                                           color={0,0,127}));
   connect(tempOutside.port, OFD.thermOutside) annotation (Line(points={{-16.5,59.5},{-35,59.5},{-35,45.05}},

--- a/AixLib/Utilities/HeatTransfer/SolarRadToHeat.mo
+++ b/AixLib/Utilities/HeatTransfer/SolarRadToHeat.mo
@@ -6,7 +6,7 @@ model SolarRadToHeat "Compute the heat flow caused by radiation on a surface"
   Modelica.Thermal.HeatTransfer.Interfaces.HeatPort_a heatPort annotation(Placement(transformation(extent={{94,-10},{114,10}}), iconTransformation(extent={{80,-30},{100,-10}})));
   AixLib.Utilities.Interfaces.SolarRad_in solarRad_in annotation(Placement(transformation(extent={{-132,-20},{-90,20}}), iconTransformation(extent={{-122,-40},{-80,0}})));
 equation
-  heatPort.Q_flow = -solarRad_in.I * A * coeff;
+  heatPort.Q_flow = -solarRad_in.H * A * coeff;
   annotation(Diagram(coordinateSystem(preserveAspectRatio = false, extent = {{-100, -100}, {100, 100}}, grid = {2, 2}), graphics={  Rectangle(extent={{-90,100},{100,-100}},    lineColor = {0, 0, 0}, fillColor = {215, 215, 215},
             fillPattern =                                                                                                   FillPattern.Solid), Text(extent={{-46,22},{-2,-22}},     lineColor = {0, 0, 0}, fillColor = {0, 0, 0},
             fillPattern =                                                                                                   FillPattern.Solid, textString = "I"), Text(extent={{10,20},{62,-24}},    lineColor = {0, 0, 0}, textString = "J"), Polygon(points={{-10,-4},{-10,4},{12,4},{12,10},{24,0},{12,-10},{12,-4},{-10,-4}},                            lineColor = {0, 0, 0})}), Icon(coordinateSystem(preserveAspectRatio = true, extent = {{-100, -100}, {100, 100}}, grid = {2, 2}), graphics={  Rectangle(extent = {{-80, 60}, {80, -100}}, lineColor = {0, 0, 0}, fillColor = {215, 215, 215},

--- a/AixLib/Utilities/Interfaces/SolarRad_in.mo
+++ b/AixLib/Utilities/Interfaces/SolarRad_in.mo
@@ -1,15 +1,16 @@
 within AixLib.Utilities.Interfaces;
 connector SolarRad_in
-  "Scalar total radiation connector (input) with additional direct, diffuse and from ground reflected radiation"
-  input Modelica.Units.SI.RadiantEnergyFluenceRate I
-    "total radiation normal to the surface";
-  input Modelica.Units.SI.RadiantEnergyFluenceRate I_dir
-    "direct radiation normal to the surface";
-  input Modelica.Units.SI.RadiantEnergyFluenceRate I_diff
-    "diffuse radiation normal to the surface";
-  input Modelica.Units.SI.RadiantEnergyFluenceRate I_gr
-    "radiation due to the ground reflection normal to the surface";
-  input Real  AOI(unit = "rad") "Angle of incidence of surface";
+  "Scalar total radiation connector (input) with additional direct, diffuse and 
+  from ground reflected radiation"
+  input Modelica.Units.SI.RadiantEnergyFluenceRate H
+    "Total solar radiation normal to the surface";
+  input Modelica.Units.SI.RadiantEnergyFluenceRate HDir
+    "Direct solar radiation normal to the surface";
+  input Modelica.Units.SI.RadiantEnergyFluenceRate HDif
+    "Diffuse solar radiation";
+  input Modelica.Units.SI.RadiantEnergyFluenceRate HGrd
+    "Ground reflected solar radiation";
+  input Modelica.Units.SI.Angle incAng "Solar incidence angle";
   annotation(Diagram(coordinateSystem(preserveAspectRatio = false, extent = {{-100, -100}, {100, 100}}), graphics={  Ellipse(extent = {{-20, 58}, {96, -58}}, lineColor = {255, 128, 0}), Rectangle(extent = {{52, 100}, {100, -100}}, lineColor = {0, 0, 0}, fillColor = {215, 215, 215},
             fillPattern =                                                                                                    FillPattern.Solid), Line(points = {{38, 62}, {38, 80}}, color = {255, 128, 0}, smooth = Smooth.Bezier), Line(points = {{-24, 0}, {-78, 0}}, color = {255, 128, 0}, smooth = Smooth.Bezier), Line(points = {{-6, 44}, {-46, 80}}, color = {255, 128, 0}, smooth = Smooth.Bezier), Line(points = {{-20, 22}, {-72, 40}}, color = {255, 128, 0}, smooth = Smooth.Bezier), Line(points = {{14, 58}, {2, 80}}, color = {255, 128, 0}, smooth = Smooth.Bezier), Line(points = {{14, -58}, {2, -80}}, color = {255, 128, 0}, smooth = Smooth.Bezier), Line(points = {{-8, -44}, {-46, -80}}, color = {255, 128, 0}, smooth = Smooth.Bezier), Line(points = {{-20, -22}, {-74, -40}}, color = {255, 128, 0}, smooth = Smooth.Bezier), Line(points = {{38, -80}, {38, -62}}, color = {255, 128, 0}, smooth = Smooth.Bezier), Polygon(points = {{0, 6}, {0, 28}, {0, 28}, {52, 0}, {0, -26}, {0, -26}, {0, -6}, {0, 6}}, lineColor = {0, 0, 0}, fillColor = {255, 0, 0},
             fillPattern =                                                                                                    FillPattern.Solid)}), Icon(coordinateSystem(preserveAspectRatio = false, extent = {{-100, -100}, {100, 100}}), graphics={  Ellipse(extent = {{-20, 58}, {96, -58}}, lineColor = {255, 128, 0}), Rectangle(extent = {{52, 100}, {100, -100}}, lineColor = {0, 0, 0}, fillColor = {215, 215, 215},
@@ -37,7 +38,7 @@ connector SolarRad_in
   <li>radiation reflected from the ground (as part of the total
   radiation)
   </li>
-  <li>angle of incidence on the surface
+  <li>incidence angle on the surface
   </li>
 </ul>
 <p>
@@ -47,23 +48,28 @@ connector SolarRad_in
   sure to write the appropriate equations for all the connector's
   components.
 </p>
+</html>", revisions="<html>
 <ul>
-  <li>
-    <i>February 22, 2015&#160;</i> by Ana Constantin:<br/>
-    Added the components of the total radiation
-  </li>
-  <li>
-    <i>Mai 19, 2014&#160;</i> by Ana Constantin:<br/>
-    Uses components from MSL and respects the naming conventions
-  </li>
-  <li>
-    <i>April 01, 2014</i> by Moritz Lauster:<br/>
-    Renamed
-  </li>
-  <li>
-    <i>April 10, 2013&#160;</i> by Ole Odendahl:<br/>
-    Formatted documentation appropriately
-  </li>
+<li>
+  March 13, 2025, by Jun Jiang:<br/>
+  Change variable names (see <a href=\"https://github.com/RWTH-EBC/AixLib/issues/1525\">issue 1525</a>)
+</li>
+<li>
+  <i>February 22, 2015&#160;</i> by Ana Constantin:<br/>
+  Added the components of the total radiation
+</li>
+<li>
+  <i>Mai 19, 2014&#160;</i> by Ana Constantin:<br/>
+  Uses components from MSL and respects the naming conventions
+</li>
+<li>
+  <i>April 01, 2014</i> by Moritz Lauster:<br/>
+  Renamed
+</li>
+<li>
+  <i>April 10, 2013&#160;</i> by Ole Odendahl:<br/>
+  Formatted documentation appropriately
+</li>
 </ul>
 </html>"));
 end SolarRad_in;

--- a/AixLib/Utilities/Interfaces/SolarRad_out.mo
+++ b/AixLib/Utilities/Interfaces/SolarRad_out.mo
@@ -1,67 +1,51 @@
 within AixLib.Utilities.Interfaces;
 connector SolarRad_out
-  "Scalar total radiation connector (output) with additional direct, diffuse and from ground reflected radiation"
-
-  output Modelica.Units.SI.RadiantEnergyFluenceRate I
-    "total radiation normal to the surface";
-  output Modelica.Units.SI.RadiantEnergyFluenceRate I_dir
-    "direct radiation normal to the surface";
-  output Modelica.Units.SI.RadiantEnergyFluenceRate I_diff
-    "diffuse radiation normal to the surface";
-  output Modelica.Units.SI.RadiantEnergyFluenceRate I_gr
-    "radiation due to the ground reflection normal to the surface";
-
-  output Real  AOI(unit = "rad") "Angle of incidence of surface";
+  "Scalar total radiation connector (output) with additional direct, diffuse and
+  from ground reflected radiation"
+  output Modelica.Units.SI.RadiantEnergyFluenceRate H
+    "Total solar radiation normal to the surface";
+  output Modelica.Units.SI.RadiantEnergyFluenceRate HDir
+    "Direct solar radiation normal to the surface";
+  output Modelica.Units.SI.RadiantEnergyFluenceRate HDif
+    "Diffuse solar radiation";
+  output Modelica.Units.SI.RadiantEnergyFluenceRate HGrd
+    "Ground reflected solar radiation";
+  output Modelica.Units.SI.Angle incAng "Solar incidence angle";
   annotation(Diagram(coordinateSystem(preserveAspectRatio = false, extent = {{-100, -100}, {100, 100}}), graphics={  Ellipse(extent = {{18, 58}, {-98, -58}}, lineColor = {255, 128, 0}), Line(points = {{-40, 62}, {-40, 80}}, color = {255, 128, 0}, smooth = Smooth.Bezier), Line(points = {{24, 0}, {78, 0}}, color = {255, 128, 0}, smooth = Smooth.Bezier), Line(points = {{6, 44}, {46, 80}}, color = {255, 128, 0}, smooth = Smooth.Bezier), Line(points = {{20, 22}, {72, 40}}, color = {255, 128, 0}, smooth = Smooth.Bezier), Line(points = {{-14, 58}, {-2, 80}}, color = {255, 128, 0}, smooth = Smooth.Bezier), Line(points = {{-14, -58}, {-2, -80}}, color = {255, 128, 0}, smooth = Smooth.Bezier), Line(points = {{8, -44}, {46, -80}}, color = {255, 128, 0}, smooth = Smooth.Bezier), Line(points = {{20, -22}, {74, -40}}, color = {255, 128, 0}, smooth = Smooth.Bezier), Line(points = {{-40, -80}, {-40, -62}}, color = {255, 128, 0}, smooth = Smooth.Bezier), Rectangle(extent = {{-100, 100}, {-60, -100}}, lineColor = {0, 0, 0}, fillColor = {215, 215, 215},
             fillPattern =                                                                                                   FillPattern.Solid), Polygon(points = {{-60, 6}, {-60, 28}, {-60, 28}, {-8, 0}, {-60, -26}, {-60, -26}, {-60, -6}, {-60, 6}}, lineColor = {0, 0, 0}, fillColor = {255, 0, 0},
             fillPattern =                                                                                                   FillPattern.Solid)}), Icon(coordinateSystem(preserveAspectRatio = false, extent = {{-100, -100}, {100, 100}}), graphics={  Ellipse(extent = {{18, 58}, {-98, -58}}, lineColor = {255, 128, 0}), Line(points = {{-40, 62}, {-40, 80}}, color = {255, 128, 0}, smooth = Smooth.Bezier), Line(points = {{24, 0}, {78, 0}}, color = {255, 128, 0}, smooth = Smooth.Bezier), Line(points = {{6, 44}, {46, 80}}, color = {255, 128, 0}, smooth = Smooth.Bezier), Line(points = {{20, 22}, {72, 40}}, color = {255, 128, 0}, smooth = Smooth.Bezier), Line(points = {{-14, 58}, {-2, 80}}, color = {255, 128, 0}, smooth = Smooth.Bezier), Line(points = {{-14, -58}, {-2, -80}}, color = {255, 128, 0}, smooth = Smooth.Bezier), Line(points = {{8, -44}, {46, -80}}, color = {255, 128, 0}, smooth = Smooth.Bezier), Line(points = {{20, -22}, {74, -40}}, color = {255, 128, 0}, smooth = Smooth.Bezier), Line(points = {{-40, -80}, {-40, -62}}, color = {255, 128, 0}, smooth = Smooth.Bezier), Rectangle(extent = {{-100, 100}, {-60, -100}}, lineColor = {0, 0, 0}, fillColor = {215, 215, 215},
             fillPattern =                                                                                                   FillPattern.Solid), Polygon(points = {{-60, 6}, {-60, 28}, {-60, 28}, {-8, 0}, {-60, -26}, {-60, -26}, {-60, -6}, {-60, 6}}, lineColor = {0, 0, 0}, fillColor = {255, 0, 0},
-            fillPattern =                                                                                                   FillPattern.Solid)}), Documentation(info="<html><p>
-  <b><span style=\"color: #008000\">Overview</span></b>
-</p>
-<p>
-  The <b>SolarRad_out</b> connector is used for the total radiation
-  output and its main components. Is explicitly defined as an output.
-</p>
-<h4>
-  <span style=\"color:#008000\">Concept</span>
-</h4>
-<p>
-  It contains information on:
-</p>
+            fillPattern =                                                                                                   FillPattern.Solid)}), Documentation(info="<html>
+<p><b><span style=\"color: #008000;\">Overview</span></b> </p>
+<p>The <b>SolarRad_out</b> connector is used for the total radiation output and its main components. Is explicitly defined as an output. </p>
+<p><b><span style=\"color: #008000;\">Concept</span> </b></p>
+<p>It contains information on: </p>
 <ul>
-  <li>total radiation
-  </li>
-  <li>direct radiation (as part of the total radiation)
-  </li>
-  <li>diffuse radiaton (as part of the total radiation)
-  </li>
-  <li>radiation reflected from the ground (as part of the total
-  radiation)
-  </li>
-  <li>angle of incidence on the surface
-  </li>
+<li>total radiation </li>
+<li>direct radiation (as part of the total radiation) </li>
+<li>diffuse radiaton (as part of the total radiation) </li>
+<li>radiation reflected from the ground (as part of the total radiation) </li>
+<li>incidence angle on the surface </li>
 </ul>
-<p>
-  <br/>
-  which can be needed by certain models, but is not neccesarry for all
-  models. As this connector replaces the old connector, please make
-  sure to write the appropriate equations for all the connector's
-  components.
-</p>
+<p><br>which can be needed by certain models, but is not neccesarry for all models. As this connector replaces the old connector, please make sure to write the appropriate equations for all the connector&apos;s components. </p>
+</html>", revisions="<html>
 <ul>
-  <li>
-    <i>Mai 19, 2014&#160;</i> by Ana Constantin:<br/>
-    Uses components from MSL and respects the naming conventions
-  </li>
-  <li>
-    <i>April 01, 2014</i> by Moritz Lauster:<br/>
-    Renamed
-  </li>
-  <li>
-    <i>April 10, 2013&#160;</i> by Ole Odendahl:<br/>
-    Formatted documentation appropriately
-  </li>
+<li>
+  March 13, 2025, by Jun Jiang:<br/>
+  Change variable names (see <a href=\"https://github.com/RWTH-EBC/AixLib/issues/1525\">issue 1525</a>)
+</li>
+<li>
+  <i>Mai 19, 2014&#160;</i> by Ana Constantin:<br/>
+  Uses components from MSL and respects the naming conventions
+</li>
+<li>
+  <i>April 01, 2014</i> by Moritz Lauster:<br/>
+  Renamed
+</li>
+<li>
+  <i>April 10, 2013&#160;</i> by Ole Odendahl:<br/>
+  Formatted documentation appropriately
+</li>
 </ul>
 </html>"));
 end SolarRad_out;

--- a/AixLib/Utilities/Sources/PrescribedSolarRad.mo
+++ b/AixLib/Utilities/Sources/PrescribedSolarRad.mo
@@ -15,11 +15,11 @@ model PrescribedSolarRad "variable radiation condition"
   Modelica.Blocks.Interfaces.RealInput AOI[n] "radiation on surface (W/m2)"
     annotation (Placement(transformation(extent={{-120,-76},{-80,-36}}), iconTransformation(extent={{-100,-80},{-80,-60}})));
 equation
-  solarRad_out[:].I = I[:] "Radiant energy fluence rate";
-  solarRad_out[:].I_dir = I_dir[:] "Radiant energy fluence rate";
-  solarRad_out[:].I_diff = I_diff[:] "Radiant energy fluence rate";
-  solarRad_out[:].I_gr = I_gr[:] "Radiant energy fluence rate";
-  solarRad_out[:].AOI = AOI[:] "Radiant energy fluence rate";
+  solarRad_out[:].H = I[:] "Radiant energy fluence rate";
+  solarRad_out[:].HDir = I_dir[:] "Radiant energy fluence rate";
+  solarRad_out[:].HDif = I_diff[:] "Radiant energy fluence rate";
+  solarRad_out[:].HGrd = I_gr[:] "Radiant energy fluence rate";
+  solarRad_out[:].incAng = AOI[:] "Radiant energy fluence rate";
 
   annotation (Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,
             -100},{100,100}}),graphics={

--- a/AixLib/Utilities/Sources/PrescribedSolarRad.mo
+++ b/AixLib/Utilities/Sources/PrescribedSolarRad.mo
@@ -1,26 +1,29 @@
 within AixLib.Utilities.Sources;
-model PrescribedSolarRad "variable radiation condition"
+model PrescribedSolarRad "Prescribed solar radiation conditions"
   parameter Integer n=1 "number of output vector length";
-  AixLib.Utilities.Interfaces.SolarRad_out solarRad_out[n] annotation (Placement(
-        transformation(extent={{80,-10},{100,10}})));
-  Modelica.Blocks.Interfaces.RealInput I[n] "radiation on surface (W/m2)"
-    annotation (Placement(transformation(extent={{-120,62},{-80,102}}), iconTransformation(extent={{-100,78},{-78,100}})));
-
-  Modelica.Blocks.Interfaces.RealInput I_dir[n] "radiation on surface (W/m2)"
-    annotation (Placement(transformation(extent={{-120,30},{-80,70}}), iconTransformation(extent={{-100,40},{-80,60}})));
-  Modelica.Blocks.Interfaces.RealInput I_diff[n] "radiation on surface (W/m2)"
-    annotation (Placement(transformation(extent={{-120,-4},{-80,36}}), iconTransformation(extent={{-100,0},{-80,20}})));
-  Modelica.Blocks.Interfaces.RealInput I_gr[n] "radiation on surface (W/m2)"
-    annotation (Placement(transformation(extent={{-120,-38},{-80,2}}), iconTransformation(extent={{-100,-42},{-78,-20}})));
-  Modelica.Blocks.Interfaces.RealInput AOI[n] "radiation on surface (W/m2)"
-    annotation (Placement(transformation(extent={{-120,-76},{-80,-36}}), iconTransformation(extent={{-100,-80},{-80,-60}})));
+  AixLib.Utilities.Interfaces.SolarRad_out solRadOut[n]
+    annotation (Placement(transformation(extent={{80,-10},{100,10}})));
+  Modelica.Blocks.Interfaces.RealInput H[n](unit="W/m2")
+    "Total radiation (W/m2)"
+    annotation (Placement(transformation(extent={{-120,60},{-80,100}})));
+  Modelica.Blocks.Interfaces.RealInput HDir[n](unit="W/m2")
+    "Direct radiation (W/m2)"
+    annotation (Placement(transformation(extent={{-120,20},{-80,60}})));
+  Modelica.Blocks.Interfaces.RealInput HDif[n](unit="W/m2")
+    "Diffuse radiation(W/m2)"
+    annotation (Placement(transformation(extent={{-120,-20},{-80,20}})));
+  Modelica.Blocks.Interfaces.RealInput HGrd[n](unit="W/m2")
+    "Ground reflected radiation (W/m2)"
+    annotation (Placement(transformation(extent={{-120,-60},{-80,-20}})));
+  Modelica.Blocks.Interfaces.RealInput incAng[n](unit="rad")
+    "Incidence angle"
+    annotation (Placement(transformation(extent={{-120,-100},{-80,-60}})));
 equation
-  solarRad_out[:].H = I[:] "Radiant energy fluence rate";
-  solarRad_out[:].HDir = I_dir[:] "Radiant energy fluence rate";
-  solarRad_out[:].HDif = I_diff[:] "Radiant energy fluence rate";
-  solarRad_out[:].HGrd = I_gr[:] "Radiant energy fluence rate";
-  solarRad_out[:].incAng = AOI[:] "Radiant energy fluence rate";
-
+  solRadOut[:].H = H[:];
+  solRadOut[:].HDir = HDir[:];
+  solRadOut[:].HDif = HDif[:];
+  solRadOut[:].HGrd = HGrd[:];
+  solRadOut[:].incAng = incAng[:];
   annotation (Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,
             -100},{100,100}}),graphics={
        Line(
@@ -59,6 +62,10 @@ equation
          pattern = LinePattern.None,
          fillPattern=FillPattern.Sphere,
          fillColor={255,255,0})}),     Documentation(revisions="<html><ul>
+  <li>
+    March 13, 2025, by Jun Jiang:<br/>
+    Change variable names (see <a href=\"https://github.com/RWTH-EBC/AixLib/issues/1525\">issue 1525</a>)
+  </li>
   <li>
     <i>February 22, 2015&#160;</i> by Ana Constantin:<br/>
     Added the components of the total radiation

--- a/AixLib/package.mo
+++ b/AixLib/package.mo
@@ -6,7 +6,7 @@ package AixLib
 	SDF(version="0.4.2"),
 	Modelica_DeviceDrivers(version="2.1.1"),
     Modelica(version="4.0.0")),
-  version="2.1.1",
+  version="2.1.2",
   conversion(from(
     version="0.3.2",
                      script="modelica://AixLib/Resources/Scripts/ConvertAixLib_from_0.3.2_to_0.4.mos",
@@ -99,7 +99,9 @@ package AixLib
 	version="2.0.0",				  
 					  script="modelica://AixLib/Resources/Scripts/ConvertAixLib_from_2.0.0_to_2.1.0.mos",
 	version="2.1.0",
-					  script="modelica://AixLib/Resources/Scripts/ConvertAixLib_from_2.1.0_to_2.1.1.mos")),
+					  script="modelica://AixLib/Resources/Scripts/ConvertAixLib_from_2.1.0_to_2.1.1.mos",
+	version="2.1.1",
+					  script="modelica://AixLib/Resources/Scripts/ConvertAixLib_from_2.1.1_to_2.1.2.mos")),
   Documentation(info = "<html><p>
   The free open-source <code>AixLib</code> library is being developed
   for research and teaching purposes. It aims at dynamic simulations of


### PR DESCRIPTION
Changes in this PR:

- Renaming solar radiation from `I` to `H` according to new naming space rules, including `I_dir` to `HDir`, `I_diff` to `HDif`, `I_gr` to `HGrd`
- Renaming solar incidence angle from `AOI` to `incAng`

One exception is the model `AixLib/ThermalZones/HighOrder/Components/WindowsDoors/BaseClasses/CorrectionSolarGain/CorG_ASHRAE140.mo`, in which internal variables `AOI` and `AOI_help` remain unchanged, to keep these internal vars similar to other vars, such as `AOR` (angle of refraction).