### PR TITLE
1593 add additional heat pump data records

### DIFF
--- a/AixLib/Fluid/HeatPumps/ModularReversible/Data/TableData2D/EN14511/Average_Heat_Pump.mo
+++ b/AixLib/Fluid/HeatPumps/ModularReversible/Data/TableData2D/EN14511/Average_Heat_Pump.mo
@@ -1,0 +1,29 @@
+within AixLib.Fluid.HeatPumps.ModularReversible.Data.TableData2D.EN14511;
+record Average_Heat_Pump "Average Heat Pump"
+  extends AixLib.Fluid.HeatPumps.ModularReversible.Data.TableData2D.GenericAirToWater(
+    dpEva_nominal=0,
+    dpCon_nominal=0,
+    tabUppBou=[253.15, 331.15; 316.15, 331.15],
+    use_TConOutForOpeEnv=true,
+    use_TEvaOutForOpeEnv=false,
+    tabQCon_flow=[
+      0, 250.15, 255.15, 260.15, 265.15, 270.15, 275.15, 280.15, 285.15, 290.15, 295.15, 300.15, 305.15, 310.15;
+      308.15, 1211.0, 1370.0, 1518.0, 1659.0, 1801.0, 1947.0, 2105.0, 2279.0, 2475.0, 2698.0, 2955.0, 3249.0, 3589.0;
+      318.15, 1154.0, 1308.0, 1454.0, 1598.0, 1742.0, 1892.0, 2053.0, 2229.0, 2425.0, 2645.0, 2893.0, 3175.0, 3495.0;
+      328.15, 1096.0, 1246.0, 1391.0, 1536.0, 1683.0, 1837.0, 2002.0, 2179.0, 2375.0, 2591.0, 2832.0, 3101.0, 3402.0;
+      333.15, 1067.0, 1215.0, 1359.0, 1505.0, 1654.0, 1810.0, 1976.0, 2155.0, 2350.0, 2564.0, 2801.0, 3064.0, 3355.0],
+    tabPEle=[
+      0, 250.15, 255.15, 260.15, 265.15, 270.15, 275.15, 280.15, 285.15, 290.15, 295.15, 300.15, 305.15, 310.15;
+      308.15, 500.0, 550.0, 570.0, 550.0, 520.0, 490.0, 460.0, 430.0, 400.0, 380.0, 370.0, 360.0, 350.0;
+      318.15, 550.0, 610.0, 630.0, 620.0, 600.0, 570.0, 530.0, 500.0, 480.0, 460.0, 440.0, 430.0, 430.0;
+      328.15, 610.0, 680.0, 720.0, 720.0, 710.0, 680.0, 650.0, 630.0, 600.0, 580.0, 560.0, 550.0, 550.0;
+      333.15, 650.0, 730.0, 770.0, 790.0, 780.0, 760.0, 740.0, 710.0, 690.0, 670.0, 660.0, 650.0, 650.0],
+    mEva_flow_nominal=1,
+    mCon_flow_nominal=13000/4180/5,
+    use_TConOutForTab=true,
+    use_TEvaOutForTab=false,
+    devIde="Average Heat Pump");
+
+  annotation (Icon(coordinateSystem(preserveAspectRatio=false)), Diagram(
+        coordinateSystem(preserveAspectRatio=false)));
+end Average_Heat_Pump;

--- a/AixLib/Fluid/HeatPumps/ModularReversible/Data/TableData2D/EN14511/NIBE_F2050_10.mo
+++ b/AixLib/Fluid/HeatPumps/ModularReversible/Data/TableData2D/EN14511/NIBE_F2050_10.mo
@@ -1,0 +1,36 @@
+﻿within AixLib.Fluid.HeatPumps.ModularReversible.Data.TableData2D.EN14511;
+record NIBE_F2050_10 "NIBE F2050 10"
+  extends
+    AixLib.Fluid.HeatPumps.ModularReversible.Data.TableData2D.GenericAirToWater(
+    dpEva_nominal=0,
+    dpCon_nominal=0,
+    tabUppBou=[253.15, 331.15; 315.15, 331.15],
+    use_TConOutForOpeEnv=true,
+    use_TEvaOutForOpeEnv=false,
+    tabQCon_flow=[
+      0, 253.15, 258.14, 263.18, 268.17, 273.21, 278.16, 280.15;
+      308.15, 5890.0, 7000.0, 8250.0, 9250.0, 10280.0, 11170.0, 11530.0;
+      318.15, 5440.0, 6530.0, 7580.0, 8690.0, 9750.0, 10810.0, 11220.0;
+      328.15, 4360.0, 5220.0, 6330.0, 7560.0, 8890.0, 10420.0, 11030.0],
+    tabPEle=[
+      0, 258.15, 263.15, 263.18, 268.15, 268.17, 273.15, 273.21, 278.15, 278.16, 280.15;
+      308.15, 2930.0, 2940.0, 2940.0, 2780.0, 2780.0, 2590.0, 2590.0, 2360.0, 2360.0, 2270.0;
+      318.15, 3570.0, 3440.0, 3440.0, 3280.0, 3280.0, 3110.0, 3110.0, 2940.0, 2940.0, 2880.0;
+      328.15, 3110.0, 3360.0, 3360.0, 3510.0, 3510.0, 3580.0, 3580.0, 3690.0, 3690.0, 3690.0],
+    mEva_flow_nominal=1,
+    mCon_flow_nominal=13000/4180/5,
+    use_TConOutForTab=true,
+    use_TEvaOutForTab=false,
+    devIde="NIBE F2050 10");
+
+// These tables were created by taking data from graphs from the manufacturer.
+// The temperature intervals are discretized based on the curvature of the curves:
+// finer resolution is used in regions with higher curvature to preserve accuracy.
+// The electrical power (Pel) is calculated using: Pel = Qmax / COP.
+// Some manufacturers don’t provide the same temperature intervals for COP and Qmax,
+// so for Pel, only the common temperature values are used to avoid extrapolation.
+// That’s why the table sizes for Qmax and Pel may be different.
+  annotation (Icon(coordinateSystem(preserveAspectRatio=false)), Diagram(
+        coordinateSystem(preserveAspectRatio=false)),
+    uses(AixLib(version="2.1.1")));
+end NIBE_F2050_10;

--- a/AixLib/Fluid/HeatPumps/ModularReversible/Data/TableData2D/EN14511/NIBE_F2120_20.mo
+++ b/AixLib/Fluid/HeatPumps/ModularReversible/Data/TableData2D/EN14511/NIBE_F2120_20.mo
@@ -1,0 +1,29 @@
+within AixLib.Fluid.HeatPumps.ModularReversible.Data.TableData2D.EN14511;
+record NIBE_F2120_20 "NIBE F2120 20"
+  extends
+    AixLib.Fluid.HeatPumps.ModularReversible.Data.TableData2D.GenericAirToWater(
+    dpEva_nominal=0,
+    dpCon_nominal=0,
+    tabUppBou=[248.15, 335.15; 264.15, 338.15; 310.15, 338.15],
+    use_TConOutForOpeEnv=true,
+    use_TEvaOutForOpeEnv=false,
+    tabQCon_flow=[
+      0, 248.15, 253.15, 258.15, 263.15, 268.15, 270.45, 273.15, 275.85, 278.15, 283.15, 288.15;
+      308.15, 10020.0, 11420.0, 12820.0, 14220.0, 15600.0, 16220.0, 16190.0, 16250.0, 16220.0, 16210.0, 16180.0;
+      318.15, 9450.0, 10850.0, 12220.0, 13660.0, 15060.0, 15590.0, 16040.0, 16280.0, 16220.0, 16240.0, 16210.0;
+      328.15, 8850.0, 10310.0, 11710.0, 13120.0, 14580.0, 15270.0, 15800.0, 16310.0, 16250.0, 16210.0, 16240.0],
+    tabPEle=[
+      0, 248.15, 253.15, 258.15, 263.15, 268.15, 270.45, 273.15, 275.85, 278.15, 283.15, 288.15;
+      308.15, 3980.0, 4120.0, 4230.0, 4240.0, 4180.0, 4150.0, 3930.0, 3730.0, 3560.0, 3210.0, 2920.0;
+      318.15, 4540.0, 4700.0, 4790.0, 4880.0, 4810.0, 4740.0, 4620.0, 4440.0, 4230.0, 3830.0, 3480.0;
+      328.15, 4810.0, 5160.0, 5370.0, 5470.0, 5540.0, 5570.0, 5510.0, 5420.0, 5190.0, 4770.0, 4410.0],
+    mEva_flow_nominal=1,
+    mCon_flow_nominal=13000/4180/5,
+    use_TConOutForTab=true,
+    use_TEvaOutForTab=false,
+    devIde="NIBE F2120 20");
+
+  annotation (Icon(coordinateSystem(preserveAspectRatio=false)), Diagram(
+        coordinateSystem(preserveAspectRatio=false)),
+    uses(AixLib(version="2.1.1")));
+end NIBE_F2120_20;

--- a/AixLib/Fluid/HeatPumps/ModularReversible/Data/TableData2D/EN14511/NIBE_S2125_12.mo
+++ b/AixLib/Fluid/HeatPumps/ModularReversible/Data/TableData2D/EN14511/NIBE_S2125_12.mo
@@ -1,0 +1,39 @@
+﻿within AixLib.Fluid.HeatPumps.ModularReversible.Data.TableData2D.EN14511;
+record NIBE_S2125_12 "NIBE S2125 12"
+  extends
+    AixLib.Fluid.HeatPumps.ModularReversible.Data.TableData2D.GenericAirToWater(
+    dpEva_nominal=0,
+    dpCon_nominal=0,
+    tabUppBou=[248.15, 338.15; 288.15, 348.15; 311.15, 348.15],
+    use_TConOutForOpeEnv=true,
+    use_TEvaOutForOpeEnv=false,
+    tabQCon_flow=[
+      0, 248.15, 253.15, 263.15, 273.15, 279.15, 283.15, 285.65, 293.15, 303.15, 311.15;
+      308.15, 4700.0, 5540.0, 7580.0, 9310.0, 9860.0, 9850.0, 9690.0, 9740.0, 9760.0, 9730.0;
+      318.15, 4720.0, 5440.0, 7500.0, 9240.0, 9690.0, 9590.0, 9340.0, 9330.0, 9320.0, 9320.0;
+      328.15, 4720.0, 5610.0, 7720.0, 9410.0, 9690.0, 9420.0, 9170.0, 9170.0, 9160.0, 9130.0],
+    tabPEle=[
+      0, 248.15, 253.15, 258.15, 263.15, 268.15, 273.15, 278.15, 279.15, 283.15, 285.65, 288.15;
+      308.15, 1870.0, 2000.0, 2170.0, 2260.0, 2260.0, 2260.0, 2150.0, 2120.0, 1950.0, 1830.0, 1750.0;
+      318.15, 2270.0, 2350.0, 2540.0, 2680.0, 2670.0, 2660.0, 2510.0, 2480.0, 2260.0, 2100.0, 2000.0;
+      328.15, 2570.0, 2800.0, 3060.0, 3220.0, 3260.0, 3280.0, 3080.0, 3040.0, 2770.0, 2590.0, 2490.0],
+    mEva_flow_nominal=1,
+    mCon_flow_nominal=13000/4180/5,
+    use_TConOutForTab=true,
+    use_TEvaOutForTab=false,
+    devIde="NIBE S2125 12");
+
+
+// These tables were created by taking data from graphs from the manufacturer.
+// The temperature intervals are discretized based on the curvature of the curves:
+// finer resolution is used in regions with higher curvature to preserve accuracy.
+// The electrical power (Pel) is calculated using: Pel = Qmax / COP.
+// Some manufacturers don’t provide the same temperature intervals for COP and Qmax,
+// so for Pel, only the common temperature values are used to avoid extrapolation.
+// That’s why the table sizes for Qmax and Pel may be different.
+
+
+  annotation (Icon(coordinateSystem(preserveAspectRatio=false)), Diagram(
+        coordinateSystem(preserveAspectRatio=false)),
+    uses(AixLib(version="2.1.1")));
+end NIBE_S2125_12;

--- a/AixLib/Fluid/HeatPumps/ModularReversible/Data/TableData2D/EN14511/Novelan_L12_Split.mo
+++ b/AixLib/Fluid/HeatPumps/ModularReversible/Data/TableData2D/EN14511/Novelan_L12_Split.mo
@@ -1,0 +1,33 @@
+within AixLib.Fluid.HeatPumps.ModularReversible.Data.TableData2D.EN14511;
+record Novelan_L12_Split "Novelan L12 Split"
+  extends
+    AixLib.Fluid.HeatPumps.ModularReversible.Data.TableData2D.GenericAirToWater(
+    dpEva_nominal=0,
+    dpCon_nominal=0,
+    tabUppBou=[253.14999999999998, 331.15; 316.15, 331.15],
+    use_TConOutForOpeEnv=true,
+    use_TEvaOutForOpeEnv=false,
+    tabQCon_flow=[
+      0, 253.15, 258.15, 263.15, 268.15, 271.9, 273.15, 278.15, 281.85;
+      308.15, 5880.0, 7060.0, 9330.0, 11240.0, 12760.0, 8360.0, 11150.0, 14820.0;
+      318.15, 5270.0, 6790.0, 9000.0, 11270.0, 13180.0, 8450.0, 10970.0, 13670.0;
+      328.15, 4450.0, 6180.0, 8120.0, 10240.0, 11820.0, 8360.0, 10640.0, 12480.0],
+    tabPEle=[
+      0, 253.15, 257.15, 258.15, 263.15, 267.15, 268.15, 271.15, 271.9, 272.15, 273.15, 278.15, 281.85;
+      308.15, 2900.0, 3050.0, 3000.0, 3520.0, 3980.0, 3990.0, 3830.0, 3770.0, 3460.0, 2340.0, 2640.0, 3100.0;
+      318.15, 2930.0, 3240.0, 3400.0, 4430.0, 5490.0, 5500.0, 6070.0, 6160.0, 5690.0, 3910.0, 4200.0, 4540.0;
+      328.15, 2750.0, 3240.0, 3400.0, 4120.0, 4590.0, 4490.0, 4420.0, 4390.0, 4090.0, 2830.0, 3110.0, 3280.0],
+    mEva_flow_nominal=1,
+    mCon_flow_nominal=13000/4180/5,
+    use_TConOutForTab=true,
+    use_TEvaOutForTab=false,
+    devIde="Novelan L12 Split");
+// These tables were created by taking data from graphs from the manufacturer.
+// The temperature intervals are discretized based on the curvature of the curves:
+// finer resolution is used in regions with higher curvature to preserve accuracy.
+// The electrical power (Pel) is calculated using: Pel = Qmax / COP.
+
+  annotation (Icon(coordinateSystem(preserveAspectRatio=false)), Diagram(
+        coordinateSystem(preserveAspectRatio=false)),
+    uses(AixLib(version="2.1.1")));
+end Novelan_L12_Split;

--- a/AixLib/Fluid/HeatPumps/ModularReversible/Data/TableData2D/EN14511/Remko_CMFCMT_180.mo
+++ b/AixLib/Fluid/HeatPumps/ModularReversible/Data/TableData2D/EN14511/Remko_CMFCMT_180.mo
@@ -1,0 +1,34 @@
+within AixLib.Fluid.HeatPumps.ModularReversible.Data.TableData2D.EN14511;
+record Remko_CMFCMT_180 "Remko CMF-CMT 180"
+  extends
+    AixLib.Fluid.HeatPumps.ModularReversible.Data.TableData2D.GenericAirToWater(
+    dpEva_nominal=0,
+    dpCon_nominal=0,
+    tabUppBou=[253.15, 313.15; 263.15, 328.15; 293.15, 328.15; 308.15, 328.15],
+    use_TConOutForOpeEnv=true,
+    use_TEvaOutForOpeEnv=false,
+    tabQCon_flow=[
+      0, 258.15, 263.15, 268.15, 273.15, 278.15, 283.15, 288.15, 293.15;
+      308.15, 4850.0, 6040.0, 6130.0, 6530.0, 7580.0, 9040.0, 10300.0, 10560.0;
+      318.15, 4990.0, 5800.0, 5980.0, 6230.0, 7030.0, 8490.0, 9890.0, 10050.0;
+      328.15, 4320.0, 5120.0, 5310.0, 5420.0, 6060.0, 7400.0, 8980.0, 9460.0],
+    tabPEle=[
+      0, 258.15, 260.15, 263.15, 266.15, 268.15, 273.15, 278.15, 280.15, 283.15, 288.15, 293.15;
+      308.15, 2210.0, 2230.0, 2240.0, 2040.0, 1940.0, 1800.0, 1860.0, 1930.0, 2010.0, 2150.0, 2020.0;
+      318.15, 2470.0, 2590.0, 2690.0, 2490.0, 2310.0, 1990.0, 1870.0, 1880.0, 1920.0, 1990.0, 1880.0;
+      328.15, 2720.0, 2710.0, 2680.0, 2490.0, 2410.0, 2210.0, 2260.0, 2390.0, 2550.0, 2880.0, 2820.0],
+    mEva_flow_nominal=1,
+    mCon_flow_nominal=13000/4180/5,
+    use_TConOutForTab=true,
+    use_TEvaOutForTab=false,
+    devIde="Remko CMF-CMT 180");
+
+// These tables were created by taking data from graphs from the manufacturer.
+// The temperature intervals are discretized based on the curvature of the curves:
+// finer resolution is used in regions with higher curvature to preserve accuracy.
+// The electrical power (Pel) is calculated using: Pel = Qmax / COP.
+
+  annotation (Icon(coordinateSystem(preserveAspectRatio=false)), Diagram(
+        coordinateSystem(preserveAspectRatio=false)),
+    uses(AixLib(version="2.1.1")));
+end Remko_CMFCMT_180;

--- a/AixLib/Fluid/HeatPumps/ModularReversible/Data/TableData2D/EN14511/Vitocal222A08.mo
+++ b/AixLib/Fluid/HeatPumps/ModularReversible/Data/TableData2D/EN14511/Vitocal222A08.mo
@@ -1,0 +1,30 @@
+within AixLib.Fluid.HeatPumps.ModularReversible.Data.TableData2D.EN14511;
+record Vitocal222A08 "Vitocal 222 A08"
+  extends AixLib.Fluid.HeatPumps.ModularReversible.Data.TableData2D.GenericAirToWater(
+    dpEva_nominal=0,
+    dpCon_nominal=0,
+    tabUppBou=[253.15, 323.15; 263.15, 333.15; 301.15, 333.15; 308.15, 328.15],
+    use_TConOutForOpeEnv=true,
+    use_TEvaOutForOpeEnv=false,
+    tabQCon_flow=[
+        0,266.15,275.15,280.15,283.15,293.15,303.15;
+        308.15,6670.0,6990.0,7540.0,8100.0,10450.0,11870.0;
+        318.15,6490.0,6850.0,7060.0,8810.0,10130.0,11460.0;
+        328.15,6640.0,6720.0,6820.0,8420.0,9780.0,11010.0;
+        333.15,6350.0,6260.0,6590.0,8000.0,9570.0,10760.0],
+    tabPEle=[
+        0,266.15,275.15,280.15,283.15,293.15,303.15;
+        308.15,2310.0,1770.0,1600.0,1580.0,1600.0,1420.0;
+        318.15,2720.0,2370.0,1970.0,2290.0,2090.0,1860.0;
+        328.15,3130.0,3010.0,2480.0,2860.0,2670.0,2380.0;
+        333.15,3310.0,3020.0,2710.0,3090.0,2990.0,2690.0],
+    mEva_flow_nominal=1,
+    mCon_flow_nominal=9776/4180/5,
+    use_TConOutForTab=true,
+    use_TEvaOutForTab=false,
+    devIde="Vitocal 222 A08");
+
+  annotation (Icon(coordinateSystem(preserveAspectRatio=false)), Diagram(
+        coordinateSystem(preserveAspectRatio=false)),
+    uses(AixLib(version="2.1.1")));
+end Vitocal222A08;

--- a/AixLib/Fluid/HeatPumps/ModularReversible/Data/TableData2D/EN14511/Vitocal222S08.mo
+++ b/AixLib/Fluid/HeatPumps/ModularReversible/Data/TableData2D/EN14511/Vitocal222S08.mo
@@ -1,0 +1,31 @@
+within AixLib.Fluid.HeatPumps.ModularReversible.Data.TableData2D.EN14511;
+record Vitocal222S08 "Vitocal 222 S08"
+  extends
+    AixLib.Fluid.HeatPumps.ModularReversible.Data.TableData2D.GenericAirToWater(
+    dpEva_nominal=0,
+    dpCon_nominal=0,
+    tabUppBou=[253.15, 323.15; 263.15, 333.15; 308.15, 333.15],
+    use_TConOutForOpeEnv=true,
+    use_TEvaOutForOpeEnv=false,
+    tabQCon_flow=[
+      0,275.15,280.15,283.15,293.15,303.15,308.15;
+      308.15,6000.0,9000.0,10860.0,13290.0,14030.0,15860.0;
+      318.15,6250.0,9480.0,10380.0,13760.0,15030.0,16000.0;
+      328.15,6120.0,8870.0,9710.0,12830.0,15240.0,15270.0;
+      333.15,6110.0,8530.0,9360.0,12260.0,14290.0,14770.0],
+    tabPEle=[
+      0,275.15,280.15,283.15,293.15,303.15,308.15;
+      308.15,1460.0,1800.0,1920.0,1890.0,1480.0,1240.0;
+      318.15,2150.0,2530.0,2490.0,2360.0,2300.0,1960.0;
+      328.15,2810.0,3070.0,3000.0,2920.0,2940.0,2580.0;
+      333.15,3040.0,3260.0,3210.0,2670.0,2750.0,2840.0],
+    mEva_flow_nominal=1,
+    mCon_flow_nominal=9776/4180/5,
+    use_TConOutForTab=true,
+    use_TEvaOutForTab=false,
+    devIde="Vitocal 222 S08");
+
+  annotation (Icon(coordinateSystem(preserveAspectRatio=false)), Diagram(
+        coordinateSystem(preserveAspectRatio=false)),
+    uses(AixLib(version="2.1.1")));
+end Vitocal222S08;

--- a/AixLib/Fluid/HeatPumps/ModularReversible/Data/TableData2D/EN14511/package.order
+++ b/AixLib/Fluid/HeatPumps/ModularReversible/Data/TableData2D/EN14511/package.order
@@ -1,10 +1,17 @@
 AlphaInnotec_LW80MA
 Dimplex_LA11AS
+NIBE_F2050_10
+NIBE_F2120_20
+NIBE_S2125_12
+Novelan_L12_Split
 Ochsner_GMLW_19
 Ochsner_GMLW_19plus
 Ochsner_GMSW_15plus
+Remko_CMFCMT_180
 SingleSplitRXM20R
 StiebelEltron_WPL18
 Vaillant_VWL_101
+Vitocal222A08
+Vitocal222S08
 Vitocal251A08
 WAMAK_WaterToWater_220kW

--- a/AixLib/Fluid/HeatPumps/ModularReversible/Data/TableData2D/EN14511/package.order
+++ b/AixLib/Fluid/HeatPumps/ModularReversible/Data/TableData2D/EN14511/package.order
@@ -1,4 +1,5 @@
 AlphaInnotec_LW80MA
+Average_Heat_Pump
 Dimplex_LA11AS
 NIBE_F2050_10
 NIBE_F2120_20


### PR DESCRIPTION
Added multiple heat pump data records (Q_max, Pel, model name, manufacturer) to EN14511 package for broader applicability. Also included a mean performance curve as a generic model when no specific heat pump is selected.

