### PR TITLE
Issue 1601: "m_flow_small" conflict warnings for DistrictHeatingCooling package PlugFlowPipeEmbedded models.

### DIFF
--- a/AixLib/Fluid/DistrictHeatingCooling/Pipes/DHCPipe.mo
+++ b/AixLib/Fluid/DistrictHeatingCooling/Pipes/DHCPipe.mo
@@ -1,4 +1,4 @@
-﻿within AixLib.Fluid.DistrictHeatingCooling.Pipes;
+within AixLib.Fluid.DistrictHeatingCooling.Pipes;
 model DHCPipe "Generic pipe model for DHC applications"
   extends AixLib.Fluid.Interfaces.PartialTwoPortInterface(show_T=true);
 
@@ -36,7 +36,7 @@ model DHCPipe "Generic pipe model for DHC applications"
   parameter Modelica.Units.SI.MassFlowRate m_flow_nominal
     "Nominal mass flow rate" annotation (Dialog(group="Nominal condition"));
 
-  parameter Modelica.Units.SI.MassFlowRate m_flow_small=1E-4*abs(m_flow_nominal)
+  parameter Modelica.Units.SI.MassFlowRate m_flow_small(min=0)=1E-4*abs(m_flow_nominal)
     "Small mass flow rate for regularization of zero flow"
     annotation (Dialog(tab="Advanced"));
 
@@ -289,7 +289,7 @@ equation
         color={0,127,255}));
 
   connect(pipCor.port_b, vol.ports[1])
-    annotation (Line(points={{10,0},{70,0},{70,20}}, color={0,127,255}));
+    annotation (Line(points={{10,0},{69,0},{69,20}}, color={0,127,255}));
   connect(pipCor.heatPort, cylHeaTra1.port_a)
     annotation (Line(points={{0,10},{0,30}}, color={191,0,0},
       pattern=LinePattern.Dash));

--- a/AixLib/Fluid/DistrictHeatingCooling/Pipes/PlugFlowPipeEmbedded.mo
+++ b/AixLib/Fluid/DistrictHeatingCooling/Pipes/PlugFlowPipeEmbedded.mo
@@ -1,4 +1,4 @@
-﻿within AixLib.Fluid.DistrictHeatingCooling.Pipes;
+within AixLib.Fluid.DistrictHeatingCooling.Pipes;
 model PlugFlowPipeEmbedded
   "Embedded pipe model using spatialDistribution for temperature delay"
 
@@ -38,7 +38,7 @@ model PlugFlowPipeEmbedded
   parameter Modelica.Units.SI.MassFlowRate m_flow_nominal
     "Nominal mass flow rate" annotation (Dialog(group="Nominal condition"));
 
-  parameter Modelica.Units.SI.MassFlowRate m_flow_small=1E-4*abs(m_flow_nominal)
+  parameter Modelica.Units.SI.MassFlowRate m_flow_small(min=0) =1E-4*abs(m_flow_nominal)
     "Small mass flow rate for regularization of zero flow"
     annotation (Dialog(tab="Advanced"));
 

--- a/AixLib/Fluid/DistrictHeatingCooling/Pipes/PlugFlowPipeZeta.mo
+++ b/AixLib/Fluid/DistrictHeatingCooling/Pipes/PlugFlowPipeZeta.mo
@@ -33,7 +33,7 @@ model PlugFlowPipeZeta
   parameter Modelica.Units.SI.MassFlowRate m_flow_nominal
     "Nominal mass flow rate" annotation (Dialog(group="Nominal condition"));
 
-  parameter Modelica.Units.SI.MassFlowRate m_flow_small=1E-4*abs(m_flow_nominal)
+  parameter Modelica.Units.SI.MassFlowRate m_flow_small(min=0)=1E-4*abs(m_flow_nominal)
     "Small mass flow rate for regularization of zero flow"
     annotation (Dialog(tab="Advanced"));
 

--- a/AixLib/Fluid/DistrictHeatingCooling/Pipes/StaticPipe.mo
+++ b/AixLib/Fluid/DistrictHeatingCooling/Pipes/StaticPipe.mo
@@ -33,7 +33,7 @@ model StaticPipe
   parameter Modelica.Units.SI.MassFlowRate m_flow_nominal
     "Nominal mass flow rate" annotation (Dialog(group="Nominal condition"));
 
-  parameter Modelica.Units.SI.MassFlowRate m_flow_small=1E-4*abs(m_flow_nominal)
+  parameter Modelica.Units.SI.MassFlowRate m_flow_small(min=0)=1E-4*abs(m_flow_nominal)
     "Small mass flow rate for regularization of zero flow"
     annotation (Dialog(tab="Advanced"));
 


### PR DESCRIPTION
This pull request is to solve the [issue 1601](https://github.com/RWTH-EBC/AixLib/issues/1601).  The definition of the m_flow_small for all the pipes in DistrictHeatingCooling/Pipes is adapted according to the PartialTwoPortinterface model to avoid the warnings.


