### PR TITLE
Fix duplicate entry in package.order

### DIFF
--- a/AixLib/Fluid/HeatExchangers/Radiators/BaseClasses/package.order
+++ b/AixLib/Fluid/HeatExchangers/Radiators/BaseClasses/package.order
@@ -5,4 +5,3 @@ PressureDropRadiator
 RadiatorTypes
 RadiatorWall
 calcHeaterExcessTemp
-RadiatorTypes


### PR DESCRIPTION
Removed duplicate entry for 'RadiatorTypes' in package order.
